### PR TITLE
fix(prefixStorage): handle missing key

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,5 @@
 import type { Storage } from './types'
-import { normalizeBase, normalizeKey } from './_utils'
+import { normalizeBase } from './_utils'
 
 const storageKeyProps: (keyof Storage)[] = [
   'hasItem',
@@ -23,7 +23,7 @@ export function prefixStorage (storage: Storage, base: string): Storage {
   const nsStorage: Storage = { ...storage }
   for (const prop of storageKeyProps) {
     // @ts-ignore Better types?
-    nsStorage[prop] = (key: string = '', ...args) => storage[prop](normalizeKey(base + key), ...args)
+    nsStorage[prop] = (key: string = '', ...args) => storage[prop](base + key, ...args)
   }
   return nsStorage
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,5 @@
 import type { Storage } from './types'
-import { normalizeBase } from './_utils'
+import { normalizeBase, normalizeKey } from './_utils'
 
 const storageKeyProps: (keyof Storage)[] = [
   'hasItem',
@@ -23,7 +23,7 @@ export function prefixStorage (storage: Storage, base: string): Storage {
   const nsStorage: Storage = { ...storage }
   for (const prop of storageKeyProps) {
     // @ts-ignore Better types?
-    nsStorage[prop] = (key: string, ...args) => storage[prop](base + key, ...args)
+    nsStorage[prop] = (key: string = '', ...args) => storage[prop](normalizeKey(base + key), ...args)
   }
   return nsStorage
 }

--- a/test/storage.test.ts
+++ b/test/storage.test.ts
@@ -33,6 +33,17 @@ describe('utils', () => {
     const storage = createStorage()
     const pStorage = prefixStorage(storage, 'foo')
     await pStorage.setItem('x', 'bar')
+    await pStorage.setItem('y', 'baz')
     expect(await storage.getItem('foo:x')).toBe('bar')
+    expect(await pStorage.getKeys()).toStrictEqual(['foo:x', 'foo:y'])
+
+    // Higher order storage
+    const secondStorage = createStorage()
+    secondStorage.mount('/mnt', storage)
+    const mntStorage = prefixStorage(secondStorage, 'mnt')
+
+    expect(await mntStorage.getKeys()).toStrictEqual(['mnt:foo:x', 'mnt:foo:y'])
+    // Get keys from sub-storage
+    expect(await mntStorage.getKeys('foo')).toStrictEqual(['mnt:foo:x', 'mnt:foo:y'])
   })
 })


### PR DESCRIPTION
`key` argument is optional in some functions, like (`getKeys`)

- Add default value for key argument to prevent undefined key (`base:undefined`)
- Normalize `base + key` to remove ending `:` in case of missing key (`base:`)