### PR TITLE
feat: allow driver getKey to receive base key

### DIFF
--- a/src/storage.ts
+++ b/src/storage.ts
@@ -39,8 +39,9 @@ export function createStorage (opts: CreateStorageOptions = {}): Storage {
 
   const getMounts = (base: string) => {
     return ctx.mountpoints
-      .filter(mountpoint => base!.length < mountpoint.length || base!.startsWith(mountpoint))
+      .filter(mountpoint => mountpoint.startsWith(base) || base!.startsWith(mountpoint))
       .map(mountpoint => ({
+        relativeBase: base.length > mountpoint.length ? base!.substr(mountpoint.length) : undefined,
         mountpoint,
         driver: ctx.mounts[mountpoint]
       }))
@@ -131,7 +132,7 @@ export function createStorage (opts: CreateStorageOptions = {}): Storage {
     async getKeys (base) {
       base = normalizeBase(base)
       const keyGroups = await Promise.all(getMounts(base).map(async (mount) => {
-        const rawKeys = await asyncCall(mount.driver.getKeys)
+        const rawKeys = await asyncCall(mount.driver.getKeys, mount.relativeBase)
         return rawKeys.map(key => mount.mountpoint + normalizeKey(key))
       }))
       const keys = keyGroups.flat()

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,7 +14,7 @@ export interface Driver {
   setItem?: (key: string, value: string) => void | Promise<void>
   removeItem?: (key: string) => void | Promise<void>
   getMeta?: (key: string) => StorageMeta | Promise<StorageMeta>
-  getKeys: () => string[] | Promise<string[]>
+  getKeys: (base?: string) => string[] | Promise<string[]>
   clear?: () => void | Promise<void>
   dispose?: () => void | Promise<void>
   watch?: (callback: WatchCallback) => void | Promise<void>


### PR DESCRIPTION
This PR allows drivers to filter out keys in `geyKeys` method.

If our driver was mounted on `/tmp/foo` and someone calls `getKeys('/tmp/foo/bar')`, the getkeys function of driver will receive `/bar` as its argument and it can filter out the result.

This will help up to improve speed/performance for some drivers like fsDriver