### PR TITLE
fix(build): use cjs extension for drivers

### DIFF
--- a/build.config.ts
+++ b/build.config.ts
@@ -6,6 +6,6 @@ export default defineBuildConfig({
     'src/index',
     'src/server',
     { input: 'src/drivers/', outDir: 'drivers', format: 'esm' },
-    { input: 'src/drivers/', outDir: 'drivers', format: 'cjs', declaration: false }
+    { input: 'src/drivers/', outDir: 'drivers', format: 'cjs', ext: 'cjs', declaration: false }
   ]
 })


### PR DESCRIPTION
`unstorage@0.3.0` exports `/drivers/*.cjs`, But with current unbuild config, driver files generates as `.js` files.

This changes enforce unbuild to use `.cjs` for drivers.