### PR TITLE
fix: handle mount overrides

### DIFF
--- a/src/storage.ts
+++ b/src/storage.ts
@@ -37,9 +37,9 @@ export function createStorage (opts: CreateStorageOptions = {}): Storage {
     }
   }
 
-  const getMounts = (base: string) => {
+  const getMounts = (base: string, includeParent: boolean) => {
     return ctx.mountpoints
-      .filter(mountpoint => mountpoint.startsWith(base) || base!.startsWith(mountpoint))
+      .filter(mountpoint => (mountpoint.startsWith(base)) || (includeParent && base!.startsWith(mountpoint)))
       .map(mountpoint => ({
         relativeBase: base.length > mountpoint.length ? base!.substring(mountpoint.length) : undefined,
         mountpoint,
@@ -131,7 +131,7 @@ export function createStorage (opts: CreateStorageOptions = {}): Storage {
     // Keys
     async getKeys (base) {
       base = normalizeBase(base)
-      const mounts = getMounts(base)
+      const mounts = getMounts(base, true)
       let maskedMounts = []
       const allKeys = []
       for (const mount of mounts) {
@@ -152,7 +152,7 @@ export function createStorage (opts: CreateStorageOptions = {}): Storage {
     // Utils
     async clear (base) {
       base = normalizeBase(base)
-      await Promise.all(getMounts(base).map(async (m) => {
+      await Promise.all(getMounts(base, false).map(async (m) => {
         if (m.driver.clear) {
           return asyncCall(m.driver.clear)
         }

--- a/test/storage.test.ts
+++ b/test/storage.test.ts
@@ -1,3 +1,4 @@
+import exp from 'constants'
 import { describe, it, expect, vi } from 'vitest'
 import { createStorage, snapshot, restoreSnapshot, prefixStorage } from '../src'
 import memory from '../src/drivers/memory'
@@ -27,7 +28,29 @@ describe('storage', () => {
     await restoreSnapshot(storage, data, 'mnt')
     expect(onChange).toHaveBeenCalledWith('update', 'mnt:data:foo')
   })
+
+  it('mount overides', async () => {
+    const storage = createStorage()
+    const subStorage = memory()
+
+    await storage.setItem('/mnt/test.txt', 'v1')
+    await storage.setItem('/mnt/test.base.txt', 'v1')
+
+    storage.mount('/mnt', subStorage)
+    await storage.setItem('/mnt/test.txt', 'v2')
+
+    expect(await storage.getItem('/mnt/test.txt')).toBe('v2')
+
+    expect(await storage.getKeys()).toMatchInlineSnapshot(`
+      [
+        "mnt:test.txt",
+        "mnt:test.txt",
+        "mnt:test.base.txt",
+      ]
+    `)
+  })
 })
+
 
 describe('utils', () => {
   it('prefixStorage', async () => {

--- a/test/storage.test.ts
+++ b/test/storage.test.ts
@@ -1,4 +1,3 @@
-import exp from 'constants'
 import { describe, it, expect, vi } from 'vitest'
 import { createStorage, snapshot, restoreSnapshot, prefixStorage } from '../src'
 import memory from '../src/drivers/memory'

--- a/test/storage.test.ts
+++ b/test/storage.test.ts
@@ -62,7 +62,6 @@ describe('storage', () => {
   })
 })
 
-
 describe('utils', () => {
   it('prefixStorage', async () => {
     const storage = createStorage()

--- a/test/storage.test.ts
+++ b/test/storage.test.ts
@@ -56,6 +56,7 @@ describe('storage', () => {
       ]
     `)
 
+    await storage.clear('/mnt')
     await storage.unmount('/mnt')
     expect(await storage.getKeys()).toMatchObject(initialKeys)
     expect(await storage.getItem('/mnt/test.txt')).toBe('v1')


### PR DESCRIPTION
Resolves #27

This PR includes two important fixes when a mount is shadowing parent (`/mnt` mounting on `/` when main mount has keys under `mnt:` namespace)
- Avoid returning parent keys with `getKeys`
- Avoid calling `clear` on the entire parent!