### PR TITLE
feat: `github` driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -477,7 +477,9 @@ const storage = createStorage({
 
 ### `github`
 
-Read files from remote github repository.
+Map files from a remote github repository. (readonly)
+
+This driver fetches all possible keys once and keep it in cache for 10 minutes. Because of github rate limit, it is highly recommanded to provide a token. It only applies to fetching keys.
 
 ```js
 import { createStorage } from 'unstorage'
@@ -494,14 +496,13 @@ const storage = createStorage({
 
 **Options:**
 
-- `repo`: Github repository. 
+- **`repo`**: Github repository. Format is `username/repo` or `org/repo`. (Required!)
+- **`token`**: Github API token. (Recommended!)
 - `branch`: Target branch. Default is `main`
-- `token`: Github API token.
 - `dir`: Use a directory as driver root.
-- `ttl`: Cache revalidate time. Default is `600`
-- `apiUrl`: Github API domain. Default is `https://api.github.com`
-- `cdnUrl`: Github RAW CDN Url. Default is `https://raw.githubusercontent.com`
-
+- `ttl`: Filenames cache revalidate time. Default is `600` seconds (10 minutes)
+- `apiURL`: Github API domain. Default is `https://api.github.com`
+- `cdnURL`: Github RAW CDN Url. Default is `https://raw.githubusercontent.com`
 
 ## Making custom drivers
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Comparing to similar solutions like [localforage](https://localforage.github.io/
   - [`http` (universal)](#http-universal)
   - [`redis`](#redis)
   - [`cloudflare-kv`](#cloudflare-kv)
+  - [`github`](#github)
 - [Making custom drivers](#making-custom-drivers)
 - [Contribution](#contribution)
 - [License](#license)
@@ -472,6 +473,34 @@ const storage = createStorage({
 **Options:**
 
 - `binding`: KV binding or name of namespace. Default is `STORAGE`.
+
+
+### `github`
+
+Read files from remote github repository.
+
+```js
+import { createStorage } from 'unstorage'
+import githubDriver from 'unstorage/drivers/github'
+
+const storage = createStorage({
+  driver: githubDriver({
+    repo: 'nuxt/framework',
+    branch: 'main',
+    dir: '/docs/content'
+  })
+})
+```
+
+**Options:**
+
+- `repo`: Github repository. 
+- `branch`: Target branch. Default is `main`
+- `token`: Github API token.
+- `dir`: Use a directory as driver root.
+- `ttl`: Cache revalidate time. Default is `600`
+- `apiUrl`: Github API domain. Default is `https://api.github.com`
+- `cdnUrl`: Github RAW CDN Url. Default is `https://raw.githubusercontent.com`
 
 
 ## Making custom drivers

--- a/src/drivers/github.ts
+++ b/src/drivers/github.ts
@@ -1,0 +1,113 @@
+import { defineDriver } from './utils'
+import { $fetch } from 'ohmyfetch'
+import { withTrailingSlash } from 'ufo'
+
+export interface GithubOptions {
+  org: string
+  repo: string
+  /**
+   * @default "main"
+   */
+  branch: string
+  /**
+   * @default ""
+   */
+  dir: string
+  token?: string
+
+  /**
+   * @default 600
+   */
+  ttl: number
+}
+
+export default defineDriver((options: GithubOptions) => {
+  const { org, repo, branch = 'main', dir, token, ttl = 600 } = options
+  const rawUrl = `https://raw.githubusercontent.com/${org}/${repo}/${branch}/${dir}`
+  
+  let files = {}
+  let lastCheck = 0
+  let isInitialized = false
+  let initialTask: Promise<any>
+
+  const syncFiles = async () => {
+    if (!isInitialized || (lastCheck + ttl * 1000) < Date.now()) {
+      if (!initialTask) initialTask = fetchFiles(options)
+      files = await initialTask
+      isInitialized = true
+      lastCheck = Date.now()
+    }
+  }
+
+  return {
+    async getKeys () {
+      await syncFiles()
+
+      return Object.keys(files)
+    },
+    async hasItem (key) {
+      await syncFiles()
+
+      return !!files[key]
+    },
+    async getItem (key) {
+      await syncFiles()
+
+      const item = files[key]
+
+      if (!item) {
+        return null
+      }
+
+      if (!item.body) {
+        try {
+          item.body = await $fetch(`${rawUrl}/${key.replace(/:/g, '/')}`, {
+            headers: {
+              Authorization: token ? `token ${token}` : undefined
+            }
+          })
+        } catch (e) {
+          // eslint-disable-next-line no-console
+          console.log(`Failed to fetch file "${key}"`, e)
+        }
+      }
+      return item.body
+    },
+    async getMeta (key) {
+      await syncFiles()
+
+      const item = files[key]
+      if (!item) {
+        return null
+      }
+      return item.meta
+    }
+  }
+})
+async function fetchFiles(options: GithubOptions) {
+  const { dir, token, branch, org, repo } = options
+  const prefix = withTrailingSlash(dir)
+  const files = {}
+  try {
+    const tree = await $fetch(`https://api.github.com/repos/${org}/${repo}/git/trees/${branch}?recursive=1`, {
+      headers: {
+        Authorization: token ? `token ${token}` : undefined
+      }
+    })
+    tree.tree.forEach((node) => {
+      if (node.type === 'blob' && node.path.startsWith(prefix)) {
+        const key = node.path.substring(prefix.length).replace(/\//g, ':')
+        files[key] = {
+          sha: node.sha,
+          meta: {
+            size: node.size
+          }
+        }
+      }
+    })
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.log('Failed to fetch git tree', e)
+  }
+  return files
+}


### PR DESCRIPTION
Create Github driver using Github API and raw CDN

- Use API to fetch files
- Use Github raw CDN to fetch file content
- Cache files to 10 minutes (configurable by `ttl`)
- Accept `dir` to load contents from specific directory