### PR TITLE
fix(drivers): add prefix key for cloudflare kv list operation

### DIFF
--- a/src/drivers/cloudflare-kv-binding.ts
+++ b/src/drivers/cloudflare-kv-binding.ts
@@ -11,8 +11,7 @@ export default defineDriver((opts: KVOptions = {}) => {
   const binding = getBinding(opts.binding)
 
   async function getKeys(base?: string) {
-    const prefix = base ? { prefix: base } : undefined
-    const kvList = await binding.list(prefix)
+    const kvList = await binding.list(base ? { prefix: base } : undefined)
     return kvList.keys.map(key => key.name)
   }
 

--- a/src/drivers/cloudflare-kv-binding.ts
+++ b/src/drivers/cloudflare-kv-binding.ts
@@ -11,7 +11,8 @@ export default defineDriver((opts: KVOptions = {}) => {
   const binding = getBinding(opts.binding)
 
   async function getKeys(base?: string) {
-    const kvList = await binding.list(base)
+    const prefix = base ? { prefix: base } : undefined
+    const kvList = await binding.list(prefix)
     return kvList.keys.map(key => key.name)
   }
 


### PR DESCRIPTION
## Type
Bugfix - Cloudflare KV Bindings driver

## Current behavior
When using the Cloudflare KV Bindings driver `getKeys(base?: string)` method with a `base` argument, an error is thrown in production.

## Description
The Cloudflare KV `list` method requires an Object `{ prefix: <base>}` to filter by prefix. This PR creates this object if a `base` argument is provided to the driver's `getKeys()` method.