### PR TITLE
fix(redis): fix reference in `clear()` method

### DIFF
--- a/src/drivers/redis.ts
+++ b/src/drivers/redis.ts
@@ -31,7 +31,7 @@ export default defineDriver<RedisOptions>((_opts) => {
       return redis.keys(r('*'))
     },
     async clear() {
-      const keys = await this.getKeys()
+      const keys = await redis.keys(r('*'))
       return redis.del(keys.map(key => r(key))).then(() => {})
     },
     dispose() {


### PR DESCRIPTION
Resolves issue #69 