### PR TITLE
fix(github): trim leading slash on `dir` prefix paths

### DIFF
--- a/src/drivers/github.ts
+++ b/src/drivers/github.ts
@@ -111,7 +111,7 @@ export default defineDriver((_opts: GithubOptions) => {
 })
 
 async function fetchFiles(opts: GithubOptions) {
-  const prefix = opts.dir ? withTrailingSlash(opts.dir) : ''
+  const prefix = withTrailingSlash(opts.dir).replace(/^\//, '')
   const files = {}
   try {
     const trees = await $fetch(`/repos/${opts.repo}/git/trees/${opts.branch}?recursive=1`, {

--- a/src/drivers/github.ts
+++ b/src/drivers/github.ts
@@ -111,7 +111,7 @@ export default defineDriver((_opts: GithubOptions) => {
 })
 
 async function fetchFiles(opts: GithubOptions) {
-  const prefix = withTrailingSlash(opts.dir)
+  const prefix = opts.dir ? withTrailingSlash(opts.dir) : ''
   const files = {}
   try {
     const trees = await $fetch(`/repos/${opts.repo}/git/trees/${opts.branch}?recursive=1`, {


### PR DESCRIPTION
This PR removes leading slashes from file tree prefixes and fixes the default config's functionality.

The Github REST API's tree paths don't contain leading slashes, so setting the `dir` option to `/docs` or leaving it as default (`''`) was causing the driver to view these trees as empty.