### PR TITLE
docs: fix `storageServer.handle` example

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,8 +290,8 @@ import { createStorageServer } from 'unstorage/server'
 const storage = createStorage()
 const storageServer = createStorageServer(storage)
 
-// Alternatively we can use `storage.handle` as a middleware
-await listen(storage.handle)
+// Alternatively we can use `storageServer.handle` as a middleware
+await listen(storageServer.handle)
 ```
 
 **Using CLI:**


### PR DESCRIPTION
Should be `storageServer` instead of `storage`, as in https://github.com/unjs/unstorage/blob/main/demo/vite.config.ts#L23