### PR TITLE
build: provide backwards-compatible type entries

### DIFF
--- a/build.config.ts
+++ b/build.config.ts
@@ -1,3 +1,6 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
 import { defineBuildConfig } from "unbuild";
 
 export default defineBuildConfig({
@@ -10,5 +13,19 @@ export default defineBuildConfig({
     "src/server",
     { input: "src/drivers/", outDir: "dist/drivers", format: "esm" },
     { input: "src/drivers/", outDir: "dist/drivers", format: "cjs", ext: "cjs", declaration: false }
-  ]
+  ],
+  hooks: {
+    async "build:done" (ctx) {
+      for (const entry of ctx.buildEntries) {
+        if (/^drivers\/.*\.d\.ts$/.test(entry.path)) {
+          const target = fileURLToPath(new URL(join("dist", entry.path), import.meta.url))
+          const declaration = fileURLToPath(new URL(entry.path, import.meta.url));
+          const relativePath = relative(dirname(declaration), target);
+
+          await mkdir(dirname(declaration), { recursive: true });
+          await writeFile(declaration, `export * from "${relativePath.slice(0, -5)}";`);
+        }
+      }
+    }
+  }
 });

--- a/build.config.ts
+++ b/build.config.ts
@@ -18,7 +18,7 @@ export default defineBuildConfig({
     async "build:done" (ctx) {
       for (const entry of ctx.buildEntries) {
         if (/^drivers\/.*\.d\.ts$/.test(entry.path)) {
-          const target = fileURLToPath(new URL(join("dist", entry.path), import.meta.url))
+          const target = fileURLToPath(new URL(join("dist", entry.path), import.meta.url));
           const declaration = fileURLToPath(new URL(entry.path, import.meta.url));
           const relativePath = relative(dirname(declaration), target);
 

--- a/build.config.ts
+++ b/build.config.ts
@@ -23,7 +23,10 @@ export default defineBuildConfig({
           const relativePath = relative(dirname(declaration), target);
 
           await mkdir(dirname(declaration), { recursive: true });
-          await writeFile(declaration, `export * from "${relativePath.slice(0, -5)}";`);
+          await writeFile(declaration, [
+            `export * from "${relativePath.slice(0, -5)}";`,
+            `export { default } from "${relativePath.slice(0, -5)}";`
+          ].join("\n"));
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "files": [
-    "dist"
+    "dist",
+    "drivers"
   ],
   "scripts": {
     "build": "unbuild",


### PR DESCRIPTION
this generates some declarations re-exporting the types from the real declarations in `dist`, for versions of typescript without subpath type support, so users get type support when doing something like:

```js
import fs from 'unstorage/drivers/fs'
```

instead of needing to do:

```ts
// @ts-expect-error
import _fs from 'unstorage/drivers/fs'
const fs = _fs as typeof import('unstorage/dist/drivers/fs')['default']
```