### PR TITLE
fix(cloudflare): pass params to kv request

### DIFF
--- a/src/drivers/cloudflare-kv-http.ts
+++ b/src/drivers/cloudflare-kv-http.ts
@@ -128,9 +128,9 @@ export default defineDriver<KVHTTPOptions>((opts) => {
   const getKeys = async (base?: string) => {
     const keys: string[] = []
 
-    const params = new URLSearchParams()
+    const params: Record<string, string> = {}
     if (base) {
-      params.set('prefix', base)
+      params.prefix = base
     }
 
     const firstPage = await kvFetch('/keys', { params })
@@ -138,17 +138,17 @@ export default defineDriver<KVHTTPOptions>((opts) => {
 
     const cursor = firstPage.result_info.cursor
     if (cursor) {
-      params.set('cursor', cursor)
+      params.cursor = cursor
     }
 
-    while (params.has('cursor')) {
-      const pageResult = await kvFetch('/keys', { params: Object.fromEntries(params.entries()) })
+    while (params.cursor) {
+      const pageResult = await kvFetch('/keys', { params })
       pageResult.result.forEach(({ name }: { name: string }) => keys.push(name))
       const pageCursor = pageResult.result_info.cursor
       if (pageCursor) {
-        params.set('cursor', pageCursor)
+        params.cursor = pageCursor
       } else {
-        params.delete('cursor')
+        delete params.cursor
       }
     }
     return keys

--- a/src/drivers/cloudflare-kv-http.ts
+++ b/src/drivers/cloudflare-kv-http.ts
@@ -142,7 +142,7 @@ export default defineDriver<KVHTTPOptions>((opts) => {
     }
 
     while (params.has('cursor')) {
-      const pageResult = await kvFetch('/keys', { params })
+      const pageResult = await kvFetch('/keys', { params: Object.fromEntries(params.entries()) })
       pageResult.result.forEach(({ name }: { name: string }) => keys.push(name))
       const pageCursor = pageResult.result_info.cursor
       if (pageCursor) {

--- a/src/drivers/cloudflare-kv-http.ts
+++ b/src/drivers/cloudflare-kv-http.ts
@@ -148,7 +148,8 @@ export default defineDriver<KVHTTPOptions>((opts) => {
       if (pageCursor) {
         params.cursor = pageCursor
       } else {
-        delete params.cursor
+        params.cursor = undefined
+
       }
     }
     return keys


### PR DESCRIPTION
### 🔗 Linked issue



### ❓ Type of change

- [x] 🧹 Chore
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Currently we spread the params within `ofetch` so we never actually end up passing any to the fetcher, meaning currently this (if the number of keys is high enough to warrant pagination) just requests the same list of keys over and over again until it times out.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
