### PR TITLE
feat: support serialization with `toJSON`

### DIFF
--- a/src/_utils.ts
+++ b/src/_utils.ts
@@ -19,11 +19,29 @@ export function asyncCall<T extends (...arguments_: any) => any>(
   }
 }
 
-export function isPrimitive(argument: any) {
-  const type = typeof argument;
-  return argument === null || (type !== "object" && type !== "function");
+function isPrimitive(value: any) {
+  const type = typeof value;
+  return value === null || (type !== "object" && type !== "function");
 }
 
-export function stringify(argument: any) {
-  return isPrimitive(argument) ? argument + "" : JSON.stringify(argument);
+function isPureObject(value: any) {
+  const proto = Object.getPrototypeOf(value);
+  // eslint-disable-next-line no-prototype-builtins
+  return !proto || proto.isPrototypeOf(Object);
+}
+
+export function stringify(value: any): string {
+  if (isPrimitive(value)) {
+    return String(value);
+  }
+
+  if (isPureObject(value)) {
+    return JSON.stringify(value);
+  }
+
+  if (typeof value.toJSON === "function") {
+    return stringify(value.toJSON());
+  }
+
+  throw new Error("[unstorage] Cannot stringify value!");
 }

--- a/src/drivers/http.ts
+++ b/src/drivers/http.ts
@@ -33,7 +33,7 @@ export default defineDriver((opts: HTTPOptions = {}) => {
       };
     },
     async setItem(key, value) {
-      await $fetch(r(key), { method: "PUT", body: stringify(value) });
+      await $fetch(r(key), { method: "PUT", body: value });
     },
     async removeItem(key) {
       await $fetch(r(key), { method: "DELETE" });

--- a/src/drivers/utils/index.ts
+++ b/src/drivers/utils/index.ts
@@ -8,15 +8,6 @@ export function defineDriver<T = any>(
   return factory;
 }
 
-export function isPrimitive(arg: any) {
-  const type = typeof arg;
-  return arg === null || (type !== "object" && type !== "function");
-}
-
-export function stringify(arg: any) {
-  return isPrimitive(arg) ? arg + "" : JSON.stringify(arg);
-}
-
 export function normalizeKey(key: string | undefined): string {
   if (!key) {
     return "";

--- a/test/drivers/utils.ts
+++ b/test/drivers/utils.ts
@@ -58,6 +58,34 @@ export function testDriver(opts: TestOptions) {
     expect(await ctx.storage.getItem("/data/true.json")).toBe(true);
   });
 
+  it("serialize (lossy object with toJSON())", async () => {
+    class Test1 {
+      toJSON() {
+        return "SERIALIZED";
+      }
+    }
+    await ctx.storage.setItem("/data/serialized1.json", new Test1());
+    expect(await ctx.storage.getItem("/data/serialized1.json")).toBe(
+      "SERIALIZED"
+    );
+    class Test2 {
+      toJSON() {
+        return { serializedObj: "works" };
+      }
+    }
+    await ctx.storage.setItem("/data/serialized2.json", new Test2());
+    expect(await ctx.storage.getItem("/data/serialized2.json")).toMatchObject({
+      serializedObj: "works",
+    });
+  });
+
+  it("serialize (error for non primitives)", async () => {
+    class Test {}
+    expect(
+      ctx.storage.setItem("/data/badvalue.json", new Test())
+    ).rejects.toThrow("[unstorage] Cannot stringify value!");
+  });
+
   if (opts.additionalTests) {
     opts.additionalTests(ctx);
   }


### PR DESCRIPTION
This PR adds support for `setItem` with lossy serialization on objects implementing `toJSON()`. Also throws an explicit error when cannot stringify instead of siltently storing wrong "object Object" strings. 