### PR TITLE
feat: raw data support (experimental)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@
 
 > 🌍 💾 Universal Storage Layer
 
-
 **Why ❓**
 
 Typically, we choose one or more data storages based on our use-cases like a filesystem, a database like Redis, Mongo, or LocalStorage for browsers but it will soon start to be lots of trouble for supporting and combining more than one or switching between them. For javascript library authors, this usually means they have to decide how many platforms they support and implement storage for each.
@@ -39,6 +38,7 @@ Comparing to similar solutions like [localforage](https://localforage.github.io/
 <br>
 
 **📚 Table of Contents**
+
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
@@ -90,11 +90,11 @@ npm i unstorage
 ```
 
 ```js
-import { createStorage } from 'unstorage'
+import { createStorage } from "unstorage";
 
-const storage = createStorage(/* opts */)
+const storage = createStorage(/* opts */);
 
-await storage.getItem('foo:bar') // or storage.getItem('/foo/bar')
+await storage.getItem("foo:bar"); // or storage.getItem('/foo/bar')
 ```
 
 **Options:**
@@ -108,15 +108,24 @@ await storage.getItem('foo:bar') // or storage.getItem('/foo/bar')
 Checks if storage contains a key. Resolves to either `true` or `false`.
 
 ```js
-await storage.hasItem('foo:bar')
+await storage.hasItem("foo:bar");
 ```
 
 ### `storage.getItem(key)`
 
-Gets the value of a key in storage. Resolves to either `string` or `undefined`.
+Gets the value of a key in storage. Resolves to either a javascript primitive value or `undefined`.
 
 ```js
-await storage.getItem('foo:bar')
+await storage.getItem("foo:bar");
+```
+
+### `storage.getItemRaw(key)` (experimental)
+
+Gets the value of a key in storage in raw format.
+
+```js
+// Value can be a Buffer, Array or Driver's raw format
+const value = await storage.getItemRaw("foo:bar.bin");
 ```
 
 ### `storage.setItem(key, value)`
@@ -128,7 +137,17 @@ If the value is not a string, it will be stringified.
 If value is `undefined`, it is same as calling `removeItem(key)`.
 
 ```js
-await storage.setItem('foo:bar', 'baz')
+await storage.setItem("foo:bar", "baz");
+```
+
+### `storage.setItemRaw(key, value)` (experimental)
+
+Add/Update a value to the storage in raw format.
+
+If value is `undefined`, it is same as calling `removeItem(key)`.
+
+```js
+await storage.setItemRaw("data/test.bin", new Uint8Array([1, 2, 3]));
 ```
 
 ### `storage.removeItem(key, removeMeta = true)`
@@ -136,7 +155,7 @@ await storage.setItem('foo:bar', 'baz')
 Remove a value (and it's meta) from storage.
 
 ```js
-await storage.removeItem('foo:bar')
+await storage.removeItem("foo:bar");
 ```
 
 ### `storage.getMeta(key, nativeOnly?)`
@@ -144,11 +163,12 @@ await storage.removeItem('foo:bar')
 Get metadata object for a specific key.
 
 This data is fetched from two sources:
+
 - Driver native meta (like file creation time)
 - Custom meta set by `storage.setMeta` (overrides driver native meta)
 
 ```js
-await storage.getMeta('foo:bar') // For fs driver returns an object like { mtime, atime, size }
+await storage.getMeta("foo:bar"); // For fs driver returns an object like { mtime, atime, size }
 ```
 
 ### `storage.setMeta(key)`
@@ -156,7 +176,7 @@ await storage.getMeta('foo:bar') // For fs driver returns an object like { mtime
 Set custom meta for a specific key by adding a `$` suffix.
 
 ```js
-await storage.setMeta('foo:bar', { flag: 1 })
+await storage.setMeta("foo:bar", { flag: 1 });
 // Same as storage.setItem('foo:bar$', { flag: 1 })
 ```
 
@@ -165,7 +185,7 @@ await storage.setMeta('foo:bar', { flag: 1 })
 Remove meta for a specific key by adding a `$` suffix.
 
 ```js
-await storage.removeMeta('foo:bar',)
+await storage.removeMeta("foo:bar");
 // Same as storage.removeItem('foo:bar$')
 ```
 
@@ -178,7 +198,7 @@ Meta keys (ending with `$`) will be filtered.
 If a base is provided, only keys starting with the base will be returned also only mounts starting with base will be queried. Keys still have a full path.
 
 ```js
-await storage.getKeys()
+await storage.getKeys();
 ```
 
 ### `storage.clear(base?)`
@@ -186,7 +206,7 @@ await storage.getKeys()
 Removes all stored key/values. If a base is provided, only mounts matching base will be cleared.
 
 ```js
-await storage.clear()
+await storage.clear();
 ```
 
 ### `storage.dispose()`
@@ -196,7 +216,7 @@ Disposes all mounted storages to ensure there are no open-handles left. Call it 
 **Note:** Dispose also clears in-memory data.
 
 ```js
-await storage.dispose()
+await storage.dispose();
 ```
 
 ### `storage.mount(mountpoint, driver)`
@@ -206,19 +226,19 @@ By default, everything is stored in memory. We can mount additional storage spac
 When operating with a `key` that starts with mountpoint, instead of default storage, mounted driver will be called.
 
 ```js
-import { createStorage } from 'unstorage'
-import fsDriver from 'unstorage/drivers/fs'
+import { createStorage } from "unstorage";
+import fsDriver from "unstorage/drivers/fs";
 
 // Create a storage container with default memory storage
-const storage = createStorage({})
+const storage = createStorage({});
 
-storage.mount('/output', fsDriver({ base: './output' }))
+storage.mount("/output", fsDriver({ base: "./output" }));
 
 //  Writes to ./output/test file
-await storage.setItem('/output/test', 'works')
+await storage.setItem("/output/test", "works");
 
 // Adds value to in-memory storage
-await storage.setItem('/foo', 'bar')
+await storage.setItem("/foo", "bar");
 ```
 
 ### `storage.unmount(mountpoint, dispose = true)`
@@ -226,7 +246,7 @@ await storage.setItem('/foo', 'bar')
 Unregisters a mountpoint. Has no effect if mountpoint is not found or is root.
 
 ```js
-await storage.unmount('/output')
+await storage.unmount("/output");
 ```
 
 ### `storage.watch(callback)`
@@ -234,9 +254,9 @@ await storage.unmount('/output')
 Starts watching on all mountpoints. If driver does not supports watching, only emits even when `storage.*` methods are called.
 
 ```js
-const unwatch = await storage.watch((event, key) => { })
+const unwatch = await storage.watch((event, key) => {});
 // to stop this watcher
-await unwatch()
+await unwatch();
 ```
 
 ### `storage.unwatch()`
@@ -244,9 +264,8 @@ await unwatch()
 Stop all watchers on all mountpoints.
 
 ```js
-await storage.unwatch()
+await storage.unwatch();
 ```
-
 
 ## Utils
 
@@ -255,9 +274,9 @@ await storage.unwatch()
 Snapshot from all keys in specified base into a plain javascript object (string: string). Base is removed from keys.
 
 ```js
-import { snapshot } from 'unstorage'
+import { snapshot } from "unstorage";
 
-const data = await snapshot(storage, '/etc')
+const data = await snapshot(storage, "/etc");
 ```
 
 ### `restoreSnapshot(storage, data, base?)`
@@ -265,7 +284,7 @@ const data = await snapshot(storage, '/etc')
 Restore snapshot created by `snapshot()`.
 
 ```js
-await restoreSnapshot(storage, { 'foo:bar': 'baz' }, '/etc2')
+await restoreSnapshot(storage, { "foo:bar": "baz" }, "/etc2");
 ```
 
 ### `prefixStorage(storage, data, base?)`
@@ -275,13 +294,13 @@ Create a namespaced instance of main storage.
 All operations are virtually prefixed. Useful to create shorcuts and limit access.
 
 ```js
-import { createStorage, prefixStorage } from 'unstorage'
+import { createStorage, prefixStorage } from "unstorage";
 
-const storage = createStorage()
-const assetsStorage = prefixStorage(storage, 'assets')
+const storage = createStorage();
+const assetsStorage = prefixStorage(storage, "assets");
 
 // Same as storage.setItem('assets:x', 'hello!')
-await assetsStorage.setItem('x', 'hello!')
+await assetsStorage.setItem("x", "hello!");
 ```
 
 ## Storage Server
@@ -295,15 +314,15 @@ Also consider that even with authentication, unstorage should not be exposed to 
 **Programmatic usage:**
 
 ```js
-import { listen } from 'listhen'
-import { createStorage } from 'unstorage'
-import { createStorageServer } from 'unstorage/server'
+import { listen } from "listhen";
+import { createStorage } from "unstorage";
+import { createStorageServer } from "unstorage/server";
 
-const storage = createStorage()
-const storageServer = createStorageServer(storage)
+const storage = createStorage();
+const storageServer = createStorageServer(storage);
 
 // Alternatively we can use `storageServer.handle` as a middleware
-await listen(storageServer.handle)
+await listen(storageServer.handle);
 ```
 
 **Using CLI:**
@@ -328,12 +347,12 @@ Maps data to the real filesystem using directory structure for nested keys. Supp
 This driver implements meta for each key including `mtime` (last modified time), `atime` (last access time), and `size` (file size) using `fs.stat`.
 
 ```js
-import { createStorage } from 'unstorage'
-import fsDriver from 'unstorage/drivers/fs'
+import { createStorage } from "unstorage";
+import fsDriver from "unstorage/drivers/fs";
 
 const storage = createStorage({
-  driver: fsDriver({ base: './tmp' })
-})
+  driver: fsDriver({ base: "./tmp" }),
+});
 ```
 
 **Options:**
@@ -347,12 +366,12 @@ const storage = createStorage({
 Store data in [localStorage](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage).
 
 ```js
-import { createStorage } from 'unstorage'
-import localStorageDriver from 'unstorage/drivers/localstorage'
+import { createStorage } from "unstorage";
+import localStorageDriver from "unstorage/drivers/localstorage";
 
 const storage = createStorage({
-  driver: localStorageDriver({ base: 'app:' })
-})
+  driver: localStorageDriver({ base: "app:" }),
+});
 ```
 
 **Options:**
@@ -368,12 +387,12 @@ Keeps data in memory using [Set](https://developer.mozilla.org/en-US/docs/Web/Ja
 By default it is mounted to top level so it is unlikely you need to mount it again.
 
 ```js
-import { createStorage } from 'unstorage'
-import memoryDriver from 'unstorage/drivers/memory'
+import { createStorage } from "unstorage";
+import memoryDriver from "unstorage/drivers/memory";
 
 const storage = createStorage({
-  driver: memoryDriver()
-})
+  driver: memoryDriver(),
+});
 ```
 
 ### `overlay` (universal)
@@ -387,19 +406,16 @@ When removing a key, a special value `__OVERLAY_REMOVED__` will be set on the to
 In the example below, we create an in-memory overlay on top of fs. No changes will be actually written to the disk.
 
 ```js
-import { createStorage } from 'unstorage'
-import overlay from 'unstorage/drivers/overlay'
-import memory from 'unstorage/drivers/memory'
-import fs from 'unstorage/drivers/fs'
+import { createStorage } from "unstorage";
+import overlay from "unstorage/drivers/overlay";
+import memory from "unstorage/drivers/memory";
+import fs from "unstorage/drivers/fs";
 
 const storage = createStorage({
   driver: overlay({
-    layers: [
-      memory(),
-      fs({ base: './data' })
-    ]
-  })
-})
+    layers: [memory(), fs({ base: "./data" })],
+  }),
+});
 ```
 
 ### `http` (universal)
@@ -409,12 +425,12 @@ Use a remote HTTP/HTTPS endpoint as data storage. Supports built-in [http server
 This driver implements meta for each key including `mtime` (last modified time) and `status` from HTTP headers by making a `HEAD` request.
 
 ```js
-import { createStorage } from 'unstorage'
-import httpDriver from 'unstorage/drivers/http'
+import { createStorage } from "unstorage";
+import httpDriver from "unstorage/drivers/http";
 
 const storage = createStorage({
-  driver: httpDriver({ base: 'http://cdn.com' })
-})
+  driver: httpDriver({ base: "http://cdn.com" }),
+});
 ```
 
 **Options:**
@@ -434,14 +450,14 @@ const storage = createStorage({
 Store data in a redis storage using [ioredis](https://github.com/luin/ioredis).
 
 ```js
-import { createStorage } from 'unstorage'
-import redisDriver from 'unstorage/drivers/redis'
+import { createStorage } from "unstorage";
+import redisDriver from "unstorage/drivers/redis";
 
 const storage = createStorage({
   driver: redisDriver({
-     base: 'storage:'
-  })
-})
+    base: "storage:",
+  }),
+});
 ```
 
 **Options:**
@@ -462,36 +478,36 @@ You need to create a KV namespace. See [KV Bindings](https://developers.cloudfla
 **Note:** This driver uses native fetch and works universally! For using directly in a cloudflare worker environemnt, please use `cloudflare-kv-binding` driver for best performance!
 
 ```js
-import { createStorage } from 'unstorage'
-import cloudflareKVHTTPDriver from 'unstorage/drivers/cloudflare-kv-http'
+import { createStorage } from "unstorage";
+import cloudflareKVHTTPDriver from "unstorage/drivers/cloudflare-kv-http";
 
 // Using `apiToken`
 const storage = createStorage({
   driver: cloudflareKVHTTPDriver({
-    accountId: 'my-account-id',
-    namespaceId: 'my-kv-namespace-id',
-    apiToken: 'supersecret-api-token',
+    accountId: "my-account-id",
+    namespaceId: "my-kv-namespace-id",
+    apiToken: "supersecret-api-token",
   }),
-})
+});
 
 // Using `email` and `apiKey`
 const storage = createStorage({
   driver: cloudflareKVHTTPDriver({
-    accountId: 'my-account-id',
-    namespaceId: 'my-kv-namespace-id',
-    email: 'me@example.com',
-    apiKey: 'my-api-key',
+    accountId: "my-account-id",
+    namespaceId: "my-kv-namespace-id",
+    email: "me@example.com",
+    apiKey: "my-api-key",
   }),
-})
+});
 
 // Using `userServiceKey`
 const storage = createStorage({
   driver: cloudflareKVHTTPDriver({
-    accountId: 'my-account-id',
-    namespaceId: 'my-kv-namespace-id',
-    userServiceKey: 'v1.0-my-service-key',
+    accountId: "my-account-id",
+    namespaceId: "my-kv-namespace-id",
+    userServiceKey: "v1.0-my-service-key",
   }),
-})
+});
 ```
 
 **Options:**
@@ -522,23 +538,23 @@ Store data in [Cloudflare KV](https://developers.cloudflare.com/workers/runtime-
 You need to create and assign a KV. See [KV Bindings](https://developers.cloudflare.com/workers/runtime-apis/kv#kv-bindings) for more information.
 
 ```js
-import { createStorage } from 'unstorage'
-import cloudflareKVBindingDriver from 'unstorage/drivers/cloudflare-kv-binding'
+import { createStorage } from "unstorage";
+import cloudflareKVBindingDriver from "unstorage/drivers/cloudflare-kv-binding";
 
 // Using binding name to be picked from globalThis
 const storage = createStorage({
-  driver: cloudflareKVBindingDriver({ binding: 'STORAGE' })
-})
+  driver: cloudflareKVBindingDriver({ binding: "STORAGE" }),
+});
 
 // Directly setting binding
 const storage = createStorage({
-  driver: cloudflareKVBindingDriver({ binding: globalThis.STORAGE })
-})
+  driver: cloudflareKVBindingDriver({ binding: globalThis.STORAGE }),
+});
 
 // Using from Durable Objects and Workers using Modules Syntax
 const storage = createStorage({
-  driver: cloudflareKVBindingDriver({ binding: this.env.STORAGE })
-})
+  driver: cloudflareKVBindingDriver({ binding: this.env.STORAGE }),
+});
 
 // Using outside of Cloudflare Workers (like Node.js)
 // Use cloudflare-kv-http!
@@ -555,16 +571,16 @@ Map files from a remote github repository. (readonly)
 This driver fetches all possible keys once and keep it in cache for 10 minutes. Because of github rate limit, it is highly recommanded to provide a token. It only applies to fetching keys.
 
 ```js
-import { createStorage } from 'unstorage'
-import githubDriver from 'unstorage/drivers/github'
+import { createStorage } from "unstorage";
+import githubDriver from "unstorage/drivers/github";
 
 const storage = createStorage({
   driver: githubDriver({
-    repo: 'nuxt/framework',
-    branch: 'main',
-    dir: '/docs/content'
-  })
-})
+    repo: "nuxt/framework",
+    branch: "main",
+    dir: "/docs/content",
+  }),
+});
 ```
 
 **Options:**
@@ -593,24 +609,24 @@ See [src/drivers](./src/drivers) to inspire how to implement them. Methods can
 **Example:**
 
 ```js
-import { createStorage, defineDriver } from 'unstorage'
+import { createStorage, defineDriver } from "unstorage";
 
 const myStorageDriver = defineDriver((_opts) => {
   return {
-    async hasItem (key) {},
-    async getItem (key) {},
+    async hasItem(key) {},
+    async getItem(key) {},
     async setItem(key, value) {},
-    async removeItem (key) {},
+    async removeItem(key) {},
     async getKeys() {},
     async clear() {},
     async dispose() {},
     // async watch(callback) {}
-  }
-})
+  };
+});
 
 const storage = createStorage({
-  driver: myStorageDriver()
-})
+  driver: myStorageDriver(),
+});
 ```
 
 ## Contribution
@@ -625,17 +641,14 @@ const storage = createStorage({
 [MIT](./LICENSE)
 
 <!-- Badges -->
+
 [npm-version-src]: https://img.shields.io/npm/v/unstorage?style=flat-square
 [npm-version-href]: https://npmjs.com/package/unstorage
-
 [npm-downloads-src]: https://img.shields.io/npm/dm/unstorage?style=flat-square
 [npm-downloads-href]: https://npmjs.com/package/unstorage
-
 [github-actions-src]: https://img.shields.io/github/workflow/status/unjs/unstorage/ci/main?style=flat-square
 [github-actions-href]: https://github.com/unjs/unstorage/actions?query=workflow%3Aci
-
 [codecov-src]: https://img.shields.io/codecov/c/gh/unjs/unstorage/main?style=flat-square
 [codecov-href]: https://codecov.io/gh/unjs/unstorage
-
 [bundle-src]: https://img.shields.io/bundlephobia/minzip/unstorage?style=flat-square
 [bundle-href]: https://bundlephobia.com/result?p=unstorage

--- a/src/_utils.ts
+++ b/src/_utils.ts
@@ -45,3 +45,33 @@ export function stringify(value: any): string {
 
   throw new Error("[unstorage] Cannot stringify value!");
 }
+
+function checkBufferSupport() {
+  if (typeof Buffer === undefined) {
+    throw new TypeError("[unstorage] Buffer is not supported!");
+  }
+}
+
+export const BASE64_PREFIX = "base64:";
+
+export function serializeRaw(value) {
+  if (typeof value === "string") {
+    return value;
+  }
+  checkBufferSupport();
+  const base64 = Buffer.from(value).toString("base64");
+  return BASE64_PREFIX + base64;
+}
+
+export function deserializeRaw(value) {
+  if (typeof value !== "string") {
+    // Return non-strings as-is
+    return value;
+  }
+  if (!value.startsWith(BASE64_PREFIX)) {
+    // Return unknown strings as-is
+    return value;
+  }
+  checkBufferSupport();
+  return Buffer.from(value.slice(BASE64_PREFIX.length), "base64");
+}

--- a/src/drivers/fs.ts
+++ b/src/drivers/fs.ts
@@ -47,6 +47,9 @@ export default defineDriver((opts: FSStorageOptions = {}) => {
       return existsSync(r(key));
     },
     getItem(key) {
+      return readFile(r(key), "utf8");
+    },
+    getItemRaw(key) {
       return readFile(r(key));
     },
     async getMeta(key) {
@@ -56,6 +59,9 @@ export default defineDriver((opts: FSStorageOptions = {}) => {
       return { atime, mtime, size };
     },
     setItem(key, value) {
+      return writeFile(r(key), value, "utf8");
+    },
+    setItemRaw(key, value) {
       return writeFile(r(key), value);
     },
     removeItem(key) {

--- a/src/drivers/memory.ts
+++ b/src/drivers/memory.ts
@@ -2,7 +2,7 @@ import { defineDriver } from "./utils";
 import type { StorageValue } from "../types";
 
 export default defineDriver(() => {
-  const data = new Map<string, StorageValue>();
+  const data = new Map<string, any>();
 
   return {
     hasItem(key) {
@@ -11,7 +11,13 @@ export default defineDriver(() => {
     getItem(key) {
       return data.get(key) || null;
     },
+    getItemRaw(key) {
+      return data.get(key) || null;
+    },
     setItem(key, value) {
+      data.set(key, value);
+    },
+    setItemRaw(key, value) {
       data.set(key, value);
     },
     removeItem(key) {

--- a/src/drivers/utils/node-fs.ts
+++ b/src/drivers/utils/node-fs.ts
@@ -9,13 +9,18 @@ function ignoreExists(err: any) {
   return err.code === "EEXIST" ? null : err;
 }
 
-export async function writeFile(path: string, data: string) {
+type WriteFileData = Parameters<typeof fsPromises.writeFile>[1];
+export async function writeFile(
+  path: string,
+  data: WriteFileData,
+  encoding?: BufferEncoding
+) {
   await ensuredir(dirname(path));
-  return fsPromises.writeFile(path, data, "utf8");
+  return fsPromises.writeFile(path, data, encoding);
 }
 
-export function readFile(path: string) {
-  return fsPromises.readFile(path, "utf8").catch(ignoreNotfound);
+export function readFile(path: string, encoding?: BufferEncoding) {
+  return fsPromises.readFile(path, encoding).catch(ignoreNotfound);
 }
 
 export function stat(path: string) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,7 +15,11 @@ export interface StorageMeta {
 export interface Driver {
   hasItem: (key: string) => MaybePromise<boolean>;
   getItem: (key: string) => StorageValue;
+  /** @experimental */
+  getItemRaw?: (key: string) => unknown;
   setItem?: (key: string, value: string) => MaybePromise<void>;
+  /** @experimental */
+  setItemRaw?: (key: string, value: any) => MaybePromise<void>;
   removeItem?: (key: string) => MaybePromise<void>;
   getMeta?: (key: string) => MaybePromise<StorageMeta>;
   getKeys: (base?: string) => MaybePromise<string[]>;
@@ -28,7 +32,11 @@ export interface Storage {
   // Item
   hasItem: (key: string) => Promise<boolean>;
   getItem: (key: string) => Promise<StorageValue>;
+  /** @experimental */
+  getItemRaw: (key: string) => Promise<any>;
   setItem: (key: string, value: StorageValue) => Promise<void>;
+  /** @experimental */
+  setItemRaw: (key: string, value: any) => Promise<void>;
   removeItem: (key: string, removeMeta?: boolean) => Promise<void>;
   // Meta
   getMeta: (key: string, nativeMetaOnly?: true) => MaybePromise<StorageMeta>;

--- a/test/drivers/cloudflare-kv-http.test.ts
+++ b/test/drivers/cloudflare-kv-http.test.ts
@@ -18,7 +18,7 @@ const server = setupServer(
     return res(
       ctx.status(200),
       ctx.set("content-type", "application/octet-stream"),
-      ctx.json(store[key])
+      ctx.body(store[key])
     );
   }),
 
@@ -30,9 +30,9 @@ const server = setupServer(
     return res(ctx.status(200), ctx.json({ success: true }));
   }),
 
-  rest.put(`${baseURL}/values/:key`, (req, res, ctx) => {
+  rest.put(`${baseURL}/values/:key`, async (req, res, ctx) => {
     const key = req.params.key as string;
-    store[key] = req.body;
+    store[key] = await req.text();
     return res(ctx.status(204), ctx.json(null));
   }),
 

--- a/test/drivers/fs.test.ts
+++ b/test/drivers/fs.test.ts
@@ -11,7 +11,7 @@ describe("drivers: fs", () => {
     driver: driver({ base: dir }),
     additionalTests(ctx) {
       it("check filesystem", async () => {
-        expect(await readFile(resolve(dir, "s1/a"))).toBe("test_data");
+        expect(await readFile(resolve(dir, "s1/a"), "utf8")).toBe("test_data");
       });
       it("native meta", async () => {
         const meta = await ctx.storage.getMeta("/s1/a");
@@ -22,7 +22,7 @@ describe("drivers: fs", () => {
       it("watch filesystem", async () => {
         const watcher = vi.fn();
         await ctx.storage.watch(watcher);
-        await writeFile(resolve(dir, "s1/random_file"), "random");
+        await writeFile(resolve(dir, "s1/random_file"), "random", "utf8");
         await new Promise((resolve) => setTimeout(resolve, 500));
         expect(watcher).toHaveBeenCalledWith("update", "s1:random_file");
       });

--- a/test/drivers/utils.ts
+++ b/test/drivers/utils.ts
@@ -86,6 +86,19 @@ export function testDriver(opts: TestOptions) {
     ).rejects.toThrow("[unstorage] Cannot stringify value!");
   });
 
+  it("raw support", async () => {
+    const value = new Uint8Array([1, 2, 3]);
+    await ctx.storage.setItemRaw("/data/raw.bin", value);
+    const rValue = await ctx.storage.getItemRaw("/data/raw.bin");
+    if (rValue.length !== value.length) {
+      console.log(rValue);
+    }
+    expect(rValue.length).toBe(value.length);
+    expect(Buffer.from(rValue).toString("base64")).toBe(
+      Buffer.from(value).toString("base64")
+    );
+  });
+
   if (opts.additionalTests) {
     opts.additionalTests(ctx);
   }


### PR DESCRIPTION
Resolves #21
Resolves #121

This PR supports the storing and retrieval of raw values using the new `getItemRaw`/`setItemRaw` interface.

Drivers can opt-in to implement `getItemRaw`/`setItemRaw` as well. When they do, unstorage directly uses this interface instead of getItem/setItem.

For drivers not supporting raw format, unstorage uses a compatibility layer to serialize and deserialize raw values with `base64:` protocol. Raw input can be any value supported by [`Buffer.from`(https://nodejs.org/api/buffer.html). This support is now added for `fs` (node) and `memory` (universal)

Followup https://github.com/unjs/unstorage/issues/142
