### PR TITLE
fix(planetscale): use `birthtime` for `created_at` value

### DIFF
--- a/src/drivers/planetscale.ts
+++ b/src/drivers/planetscale.ts
@@ -78,7 +78,7 @@ export default defineDriver((opts: PlanetscaleDriverOptions = {}) => {
         { key }
       );
       return {
-        ctime: rows(res)[0]?.created_at,
+        birthtime: rows(res)[0]?.created_at,
         mtime: rows(res)[0]?.updated_at,
       };
     },

--- a/src/drivers/planetscale.ts
+++ b/src/drivers/planetscale.ts
@@ -78,7 +78,7 @@ export default defineDriver((opts: PlanetscaleDriverOptions = {}) => {
         { key }
       );
       return {
-        atime: rows(res)[0]?.created_at,
+        ctime: rows(res)[0]?.created_at,
         mtime: rows(res)[0]?.updated_at,
       };
     },


### PR DESCRIPTION
Oops, just spotted this typo.