### PR TITLE
feat(driver): add basic `cache` driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,6 +383,26 @@ const storage = createStorage({
 });
 ```
 
+### `cache`
+
+This driver can be combined with any other driver to automatically cache reads using the `memory` driver but still perform write operations. (It is almost the reverse of the `overlay` driver.)
+
+```js
+import { createStorage } from "unstorage";
+import cacheDriver from "unstorage/drivers/cache";
+import httpDriver from "unstorage/drivers/http";
+
+const storage = createStorage({
+  driver: cacheDriver({
+    driver: httpDriver({ base: "http://cdn.com" }),
+  }),
+});
+```
+
+**Options:**
+
+- `driver`: A configured driver to cache automatically.
+
 ### `http` (universal)
 
 Use a remote HTTP/HTTPS endpoint as data storage. Supports built-in [http server](#storage-server) methods.

--- a/src/drivers/cache.ts
+++ b/src/drivers/cache.ts
@@ -1,0 +1,36 @@
+import type { Driver } from '../types'
+import memoryDriver from './memory'
+import { defineDriver } from './utils'
+
+export interface CacheDriverOptions {
+  driver: Driver
+}
+
+export default defineDriver((opts: CacheDriverOptions) => {
+  const driver = opts.driver || memoryDriver()
+  const memory = memoryDriver()
+  return {
+    ...driver,
+    async hasItem(key) {
+      if (await memory.hasItem(key))
+        return true
+
+      return driver.hasItem(key)
+    },
+    async setItem(key, value: any) {
+      driver.setItem?.(key, value),
+      await memory.setItem(key, value)
+    },
+    async getItem(key) {
+      let value = memory.getItem(key)
+
+      if (value !== null)
+        return value
+
+      value = await driver.getItem(key)
+      memory.setItem(key, value)
+
+      return value
+    },
+  }
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ export * from "./utils";
 export { defineDriver } from "./drivers/utils";
 
 export const builtinDrivers = {
+  cache: "unstorage/drivers/cache",
   cloudflareKVHTTP: "unstorage/drivers/cloudflare-kv-http",
   cloudflareKVBinding: "unstorage/drivers/cloudflare-kv-binding",
   "cloudflare-kv-http": "unstorage/drivers/cloudflare-kv-http",


### PR DESCRIPTION
### 🔗 Linked issue

maybe https://github.com/unjs/unstorage/issues/15 ?

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This is a driver that can wrap another drive to provide automatic caching of `hasItem`, `setItem` and `getItem`

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
