### PR TITLE
fix: allow stringify array

### DIFF
--- a/src/_utils.ts
+++ b/src/_utils.ts
@@ -35,7 +35,7 @@ export function stringify(value: any): string {
     return String(value);
   }
 
-  if (isPureObject(value)) {
+  if (isPureObject(value) || Array.isArray(value)) {
     return JSON.stringify(value);
   }
 

--- a/test/storage.test.ts
+++ b/test/storage.test.ts
@@ -109,4 +109,9 @@ describe("utils", () => {
     // Get keys from sub-storage
     expect(await mntStorage.getKeys("foo")).toStrictEqual(["foo:x", "foo:y"]);
   });
+
+  it("stringify", () => {
+    const storage = createStorage();
+    expect(async () => await storage.setItem("foo", [])).not.toThrow();
+  });
 });


### PR DESCRIPTION
With the new "stringify" implementation, trying to store an array throws an error. Here's a simple repro: https://stackblitz.com/edit/typescript-xvqbbc?file=index.ts