### PR TITLE
redisDriver adds the setKeyExpire method to set the expiration time of the key. After the key expires, it will no longer be available. The unit is in seconds.

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,16 @@ If value is `undefined`, it is same as calling `removeItem(key)`.
 await storage.setItem("foo:bar", "baz");
 ```
 
+### `storage.setKeyExpire(key, seconds)`
+
+Set the expiration time of the key. After the key expires, it will no longer be available. The unit is in seconds.
+
+**Note:** Only for redisDriver.
+
+```js
+await storage.setKeyExpire("foo:bar", 1); // 1s
+```
+
 ### `storage.setItemRaw(key, value)`
 
 **Note:** This is an experimental feature. Please check [unjs/unstorage#142](https://github.com/unjs/unstorage/issues/142) for more information.

--- a/src/drivers/redis.ts
+++ b/src/drivers/redis.ts
@@ -26,6 +26,9 @@ export default defineDriver<RedisOptions>((_opts) => {
     setItem(key, value) {
       return redis.set(r(key), value).then(() => {});
     },
+    setKeyExpire(key, seconds) {
+      return redis.expire(r(key), seconds).then(() => {});
+    },
     removeItem(key) {
       return redis.del(r(key)).then(() => {});
     },

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -137,6 +137,23 @@ export function createStorage(options: CreateStorageOptions = {}): Storage {
         onChange("update", key);
       }
     },
+    async setKeyExpire(key, seconds) {
+      if (seconds === undefined) {
+        return; // Readonly
+      }
+
+      key = normalizeKey(key);
+      const { relativeKey, driver } = getMount(key);
+      if (!driver.setKeyExpire) {
+        return; // Readonly
+      }
+
+      await asyncCall(driver.setKeyExpire, relativeKey, seconds);
+
+      if (!driver.watch) {
+        onChange("update", key);
+      }
+    },
     async setItemRaw(key, value) {
       if (value === undefined) {
         return storage.removeItem(key);

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,6 +19,7 @@ export interface Driver {
   getItemRaw?: (key: string) => MaybePromise<unknown>;
   setItem?: (key: string, value: string) => MaybePromise<void>;
   /** @experimental */
+  setKeyExpire?: (key: string, seconds: number) => MaybePromise<void>;
   setItemRaw?: (key: string, value: any) => MaybePromise<void>;
   removeItem?: (key: string) => MaybePromise<void>;
   getMeta?: (key: string) => MaybePromise<StorageMeta>;
@@ -36,6 +37,7 @@ export interface Storage {
   getItemRaw: (key: string) => Promise<any>;
   setItem: (key: string, value: StorageValue) => Promise<void>;
   /** @experimental See https://github.com/unjs/unstorage/issues/142 */
+  setKeyExpire: (key: string, seconds: number) => Promise<void>;
   setItemRaw: (key: string, value: any) => Promise<void>;
   removeItem: (key: string, removeMeta?: boolean) => Promise<void>;
   // Meta

--- a/test/drivers/redis.test.ts
+++ b/test/drivers/redis.test.ts
@@ -1,0 +1,26 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createStorage } from "../../src";
+import driver from "../../src/drivers/redis";
+
+
+describe("drivers: redis", () => {
+
+    it('setKeyExpire', async () => {
+        const storage = createStorage({
+            driver: driver({
+                url: 'redis://:pwd.@127.0.0.1:6379',
+                base: ''
+            })
+        });
+
+        await storage.setItem('hello', 'unstorage');
+        await storage.setKeyExpire('hello', 5);
+        expect(await storage.getItem("hello")).toBe("unstorage");
+
+
+        await new Promise(resolve => setTimeout(resolve, 1000 * 5));
+
+        expect(await storage.hasItem("hello")).toBe(false);
+
+    }, 1000 * 10);
+});


### PR DESCRIPTION
### `storage.setKeyExpire(key, seconds)`

Set the expiration time of the key. After the key expires, it will no longer be available. The unit is in seconds.

**Note:** Only for redisDriver.

```js
await storage.setKeyExpire("foo:bar", 1); // 1s
```

Test file path: test/drivers/redis.test.ts.

Before testing, you need to modify the ip, password, and port in the file.