### PR TITLE
feat(redis): support native `ttl`

### DIFF
--- a/docs/content/6.drivers/redis.md
+++ b/docs/content/6.drivers/redis.md
@@ -55,6 +55,6 @@ See [ioredis](https://github.com/luin/ioredis/blob/master/API.md#new-redisport-h
 
 `lazyConnect` option is enabled by default so that connection happens on first redis operation.
 
-**Operation options:**
+**Transaction options:**
 
 - `ttl`: Supported for `setItem(key, value, { ttl: number /* seconds */ })`

--- a/docs/content/6.drivers/redis.md
+++ b/docs/content/6.drivers/redis.md
@@ -49,7 +49,12 @@ const storage = createStorage({
 - `url`: Url to use for connecting to redis. Takes precedence over `host` option. Has the format `redis://<REDIS_USER>:<REDIS_PASSWORD>@<REDIS_HOST>:<REDIS_PORT>`
 - `cluster`: List of redis nodes to use for cluster mode. Takes precedence over `url` and `host` options.
 - `clusterOptions`: Options to use for cluster mode.
+- `ttl`: Default TTL for all items in **seconds**.
 
 See [ioredis](https://github.com/luin/ioredis/blob/master/API.md#new-redisport-host-options) for all available options.
 
 `lazyConnect` option is enabled by default so that connection happens on first redis operation.
+
+**Operation options:**
+
+- `ttl`: Supported for `setItem(key, value, { ttl: number /* seconds */ })`

--- a/src/drivers/redis.ts
+++ b/src/drivers/redis.ts
@@ -26,6 +26,11 @@ export interface RedisOptions extends _RedisOptions {
    * Options to use for cluster mode.
    */
   clusterOptions?: ClusterOptions;
+
+  /**
+   * Default TTL for all items in seconds.
+   */
+  ttl?: number;
 }
 
 export default defineDriver((opts: RedisOptions = {}) => {
@@ -60,8 +65,13 @@ export default defineDriver((opts: RedisOptions = {}) => {
       const value = await getRedisClient().get(p(key));
       return value === null ? null : value;
     },
-    async setItem(key, value) {
-      await getRedisClient().set(p(key), value);
+    async setItem(key, value, tOptions) {
+      let ttl = tOptions?.ttl ?? opts.ttl;
+      if (ttl) {
+        await getRedisClient().set(p(key), value, "EX", tOptions.ttl);
+      } else {
+        await getRedisClient().set(p(key), value);
+      }
     },
     async removeItem(key) {
       await getRedisClient().del(p(key));


### PR DESCRIPTION
Resolves #35

Support setting ttl for all setItem operations or per setItem using new transaction options