### PR TITLE
feat(lru-cache): support `maxSize` and `maxEntrySize`

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+test/drivers/tmp

--- a/docs/content/6.drivers/lru-cache.md
+++ b/docs/content/6.drivers/lru-cache.md
@@ -6,7 +6,11 @@ navigation.title: LRU Cache
 
 Keeps cached data in memory using [LRU Cache](https://www.npmjs.com/package/lru-cache).
 
-See [`lru-cache`](https://www.npmjs.com/package/lru-cache) for supported options. By default `{ max: 500 }` is used.
+See [`lru-cache`](https://www.npmjs.com/package/lru-cache) for supported options.
+
+By default [`max`](https://www.npmjs.com/package/lru-cache#max) setting is set to `1000` items.
+
+A default behavior for [`sizeCalculation`](https://www.npmjs.com/package/lru-cache#sizecalculation) option is implemented based on buffer size of both key and value.
 
 ```js
 import { createStorage } from "unstorage";

--- a/test/drivers/lru-cache.test.ts
+++ b/test/drivers/lru-cache.test.ts
@@ -1,9 +1,29 @@
-import { describe } from "vitest";
+import { it, describe, expect } from "vitest";
 import driver from "../../src/drivers/lru-cache";
 import { testDriver } from "./utils";
 
 describe("drivers: lru-cache", () => {
   testDriver({
     driver: driver(),
+  });
+});
+
+describe("drivers: lru-cache with size", () => {
+  testDriver({
+    driver: driver({
+      maxEntrySize: 50,
+    }),
+    additionalTests({ storage }) {
+      it("should not store large items", async () => {
+        await storage.setItem(
+          "big",
+          "0123456789012345678901234567890123456789012345678901234567890123456789"
+        );
+        expect(await storage.getItem("big")).toBe(null);
+
+        await storage.setItemRaw("bigBuff", Buffer.alloc(100));
+        expect(await storage.getItemRaw("bigBuff")).toBe(null);
+      });
+    },
   });
 });

--- a/test/drivers/utils.ts
+++ b/test/drivers/utils.ts
@@ -13,12 +13,11 @@ export interface TestOptions {
 
 export function testDriver(opts: TestOptions) {
   const ctx: TestContext = {
-    storage: createStorage(),
+    storage: createStorage({ driver: opts.driver }),
     driver: opts.driver,
   };
 
   it("init", async () => {
-    ctx.storage = createStorage({ driver: opts.driver });
     await restoreSnapshot(ctx.storage, { initial: "works" });
     expect(await ctx.storage.getItem("initial")).toBe("works");
     await ctx.storage.clear();
@@ -92,15 +91,16 @@ export function testDriver(opts: TestOptions) {
     const value = new Uint8Array([1, 2, 3]);
     await ctx.storage.setItemRaw("/data/raw.bin", value);
     const rValue = await ctx.storage.getItemRaw("/data/raw.bin");
-    if (rValue.length !== value.length) {
+    if (rValue?.length !== value.length) {
       console.log(rValue);
     }
-    expect(rValue.length).toBe(value.length);
+    expect(rValue?.length).toBe(value.length);
     expect(Buffer.from(rValue).toString("base64")).toBe(
       Buffer.from(value).toString("base64")
     );
   });
 
+  // TODO: Refactor to move after cleanup
   if (opts.additionalTests) {
     opts.additionalTests(ctx);
   }


### PR DESCRIPTION
Support `maxSize` and `maxEntrySize` for lru-cache driver with built-in size calculation setup