### PR TITLE
fix(pkg): use optional peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "vitest": "^0.29.2",
     "vue": "^3.2.47"
   },
-  "optionalDependencies": {
+  "peerDependencies": {
     "@azure/app-configuration": "^1.3.1",
     "@azure/cosmos": "^3.17.3",
     "@azure/data-tables": "^13.2.1",
@@ -98,6 +98,29 @@
     "@azure/keyvault-secrets": "^4.6.0",
     "@azure/storage-blob": "^12.13.0",
     "@planetscale/database": "^1.6.0"
+  },
+  "peerDependenciesMeta": {
+    "@azure/app-configuration": {
+      "optional": true
+    },
+    "@azure/cosmos": {
+      "optional": true
+    },
+    "@azure/data-tables": {
+      "optional": true
+    },
+    "@azure/identity": {
+      "optional": true
+    },
+    "@azure/keyvault-secrets": {
+      "optional": true
+    },
+    "@azure/storage-blob": {
+      "optional": true
+    },
+    "@planetscale/database": {
+      "optional": true
+    }
   },
   "packageManager": "pnpm@7.29.0"
 }


### PR DESCRIPTION
resolves #182

pnpm seems to install all optional dependencies.

<img width="759" alt="image" src="https://user-images.githubusercontent.com/5158436/224371592-5fbf9e50-99fe-478e-a11d-bbd92f7f8436.png">


Using `peerDependencies` + `optional` meta to fix this.