### PR TITLE
fix(github): optional properties

### DIFF
--- a/src/drivers/github.ts
+++ b/src/drivers/github.ts
@@ -12,15 +12,15 @@ export interface GithubOptions {
    * The branch to fetch. (e.g. `dev`)
    * @default "main"
    */
-  branch: string;
+  branch?: string;
   /**
-   * @default ""
+   * @default "main"
    */
-  dir: string;
+  dir?: string;
   /**
    * @default 600
    */
-  ttl: number;
+  ttl?: number;
   /**
    * Github API token (recommended)
    */


### PR DESCRIPTION
The supposedly optional driver properties aren't optional on the interface, which makes configuration more work than it needs to be.

This PR makes `branch`, `dir` and `ttl` optional, as they have defaults.