### PR TITLE
docs: fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Unstorage provides an async Key-Value storage API with conventional features lik
 - Default [in-memory](https://unstorage.unjs.io/drivers/memory) storage
 - Tree-shakable utils and tiny core
 - Auto JSON value serialization and deserialization
-- Banary and raw value support
+- Binary and raw value support
 - State [snapshots](https://unstorage.unjs.io/utils#snapshots) and hydration
 - Storage watcher
 - HTTP Storage with [built-in server](https://unstorage.unjs.io/http-server)

--- a/docs/content/1.index.md
+++ b/docs/content/1.index.md
@@ -21,7 +21,7 @@ We usually choose one or more storage backends based on our use-cases such as fi
 - Default [in-memory](/drivers/memory) storage
 - Tree-shakable utils and tiny core
 - Auto JSON value serialization and deserialization
-- Banary and raw value support
+- Binary and raw value support
 - State [snapshots](/utils#snapshots) and hydration
 - Storage watcher
 - HTTP Storage with [built-in server](/server)


### PR DESCRIPTION
This is a straightforward typo fix.

Followed the instructions in `docs/README.md` and checked that the fix worked.