### PR TITLE
feat: support cloudflare options with setItem

### DIFF
--- a/docs/content/6.drivers/cloudflare-kv-binding.md
+++ b/docs/content/6.drivers/cloudflare-kv-binding.md
@@ -41,8 +41,11 @@ Refer to the [cloudflare KV docs](https://developers.cloudflare.com/workers/runt
 
 ```ts
 await storage.setItem("key", "value", {
-  expiration: 1578435000,
-  expirationTtl: 300,
-  metadata: { someMetadataKey: "someMetadataValue" },
+  ttl: 300, // key expiration shorthand (in seconds)
+  cloudflareKvBinding: {
+    expiration: 1578435000,
+    expirationTtl: 300,
+    metadata: { someMetadataKey: "someMetadataValue" },
+  },
 });
 ```

--- a/docs/content/6.drivers/cloudflare-kv-binding.md
+++ b/docs/content/6.drivers/cloudflare-kv-binding.md
@@ -33,3 +33,16 @@ const storage = createStorage({
 
 - `binding`: KV binding or name of namespace. Default is `STORAGE`.
 - `base`: Adds prefix to all stored keys
+
+## Using Cloudlflare KV Options
+
+You can pass options to cloudflare such as metadata and expiration as the 3rd argument of the `setItem` function.
+Refer to the [cloudflare KV docs](https://developers.cloudflare.com/workers/runtime-apis/kv/#writing-key-value-pairs) for the list of supported options.
+
+```ts
+await storage.setItem("key", "value", {
+  expiration: 1578435000,
+  expirationTtl: 300,
+  metadata: { someMetadataKey: "someMetadataValue" },
+});
+```

--- a/docs/content/6.drivers/cloudflare-kv-http.md
+++ b/docs/content/6.drivers/cloudflare-kv-http.md
@@ -66,9 +66,12 @@ Refer to the [cloudflare KV API docs](https://developers.cloudflare.com/api/oper
 
 ```ts
 await storage.setItem("key", "value", {
-  expiration: 1578435000,
-  expiration_ttl: 300,
-  base64: false,
-  metadata: { someMetadataKey: "someMetadataValue" },
+  ttl: 300, // key expiration shorthand (in seconds)
+  cloudflareKvHttp: {
+    expiration: 1578435000,
+    expiration_ttl: 300,
+    base64: false,
+    metadata: { someMetadataKey: "someMetadataValue" },
+  },
 });
 ```

--- a/docs/content/6.drivers/cloudflare-kv-http.md
+++ b/docs/content/6.drivers/cloudflare-kv-http.md
@@ -58,3 +58,17 @@ const storage = createStorage({
 - `removeItem`: Maps to [Delete key-value pair](https://api.cloudflare.com/#workers-kv-namespace-delete-key-value-pair) `DELETE accounts/:account_identifier/storage/kv/namespaces/:namespace_identifier/values/:key_name`
 - `getKeys`: Maps to [List a Namespace's Keys](https://api.cloudflare.com/#workers-kv-namespace-list-a-namespace-s-keys) `GET accounts/:account_identifier/storage/kv/namespaces/:namespace_identifier/keys`
 - `clear`: Maps to [Delete key-value pair](https://api.cloudflare.com/#workers-kv-namespace-delete-multiple-key-value-pairs) `DELETE accounts/:account_identifier/storage/kv/namespaces/:namespace_identifier/bulk`
+
+## Using Cloudlflare KV Options
+
+You can pass cloudflare options such as metadata and expiration as the 3rd argument of the `setItem` function.
+Refer to the [cloudflare KV API docs](https://developers.cloudflare.com/api/operations/workers-kv-namespace-write-multiple-key-value-pairs) for the list of supported options.
+
+```ts
+await storage.setItem("key", "value", {
+  expiration: 1578435000,
+  expiration_ttl: 300,
+  base64: false,
+  metadata: { someMetadataKey: "someMetadataValue" },
+});
+```

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "@vue/compiler-sfc": "^3.3.4",
     "azurite": "^3.24.0",
     "changelogen": "^0.5.4",
+    "defu": "^6.1.2",
     "eslint": "^8.44.0",
     "eslint-config-unjs": "^0.2.1",
     "ioredis-mock": "^8.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,6 +97,9 @@ devDependencies:
   changelogen:
     specifier: ^0.5.4
     version: 0.5.4
+  defu:
+    specifier: ^6.1.2
+    version: 6.1.2
   eslint:
     specifier: ^8.44.0
     version: 8.44.0

--- a/src/drivers/cloudflare-kv-binding.ts
+++ b/src/drivers/cloudflare-kv-binding.ts
@@ -46,8 +46,8 @@ export default defineDriver((opts: KVOptions = {}) => {
     setItem(key, value, options) {
       const binding = getBinding(opts.binding);
       const cloudflareOptions = defu(
-        options.cloudflareKvBinding,
-        options.ttl
+        options?.cloudflareKvBinding,
+        options?.ttl
           ? { expirationTtl: options.ttl }
           : opts.ttl
           ? { expirationTtl: opts.ttl }

--- a/src/drivers/cloudflare-kv-binding.ts
+++ b/src/drivers/cloudflare-kv-binding.ts
@@ -44,8 +44,9 @@ export default defineDriver((opts: KVOptions = {}) => {
       return binding.get(key);
     },
     setItem(key, value, options) {
+      key = r(key);
       const binding = getBinding(opts.binding);
-      const cloudflareOptions = defu(
+      const o = defu(
         options?.cloudflareKvBinding,
         options?.ttl
           ? { expirationTtl: options.ttl }
@@ -53,7 +54,7 @@ export default defineDriver((opts: KVOptions = {}) => {
           ? { expirationTtl: opts.ttl }
           : {}
       );
-      return binding.put(key, value, cloudflareOptions);
+      return binding.put(key, value, o);
     },
     removeItem(key) {
       key = r(key);

--- a/src/drivers/cloudflare-kv-binding.ts
+++ b/src/drivers/cloudflare-kv-binding.ts
@@ -13,6 +13,9 @@ export interface KVOptions {
   ttl?: number;
 }
 
+//https://developers.cloudflare.com/workers/runtime-apis/kv#writing-key-value-pairs
+export type CloudflareKvBindingSetItemOptions = KVNamespacePutOptions;
+
 // https://developers.cloudflare.com/workers/runtime-apis/kv
 
 const DRIVER_NAME = "cloudflare-kv-binding";
@@ -40,15 +43,16 @@ export default defineDriver((opts: KVOptions = {}) => {
       const binding = getBinding(opts.binding);
       return binding.get(key);
     },
-    setItem(
-      key,
-      value,
-      options: { cloudflare?: Record<string, unknown>; ttl?: number }
-    ) {
+    setItem(key, value, options) {
       const binding = getBinding(opts.binding);
-      const cloudflareOptions = defu(options, {
-        expirationTtl: options.ttl ?? opts.ttl ?? undefined,
-      });
+      const cloudflareOptions = defu(
+        options.cloudflareKvBinding,
+        options.ttl
+          ? { expirationTtl: options.ttl }
+          : opts.ttl
+          ? { expirationTtl: opts.ttl }
+          : {}
+      );
       return binding.put(key, value, cloudflareOptions);
     },
     removeItem(key) {

--- a/src/drivers/cloudflare-kv-binding.ts
+++ b/src/drivers/cloudflare-kv-binding.ts
@@ -34,10 +34,9 @@ export default defineDriver((opts: KVOptions = {}) => {
       const binding = getBinding(opts.binding);
       return binding.get(key);
     },
-    setItem(key, value) {
-      key = r(key);
+    setItem(key, value, options) {
       const binding = getBinding(opts.binding);
-      return binding.put(key, value);
+      return binding.put(key, value, options);
     },
     removeItem(key) {
       key = r(key);

--- a/src/drivers/cloudflare-kv-http.ts
+++ b/src/drivers/cloudflare-kv-http.ts
@@ -152,7 +152,7 @@ export default defineDriver<KVHTTPOptions>((opts) => {
   const r = (key: string = "") => (opts.base ? joinKeys(opts.base, key) : key);
 
   const hasItem = async (key: string) => {
-    const response = await kvFetch(`/metadata/${key}`);
+    const response = await kvFetch(`/metadata/${r(key)}`);
     if (response.status === 404) return false;
     const data = await response.json<{ success: boolean }>();
     return data?.success === true;
@@ -160,7 +160,7 @@ export default defineDriver<KVHTTPOptions>((opts) => {
 
   const getItem = async (key: string) => {
     // Cloudflare API returns with `content-type: application/json`: https://developers.cloudflare.com/api/operations/workers-kv-namespace-read-key-value-pair
-    const response = await kvFetch(`/values/${key}`);
+    const response = await kvFetch(`/values/${r(key)}`);
     if (response.status === 404) return null;
     return response.json();
   };
@@ -180,12 +180,12 @@ export default defineDriver<KVHTTPOptions>((opts) => {
     );
     await kvFetch(`/bulk`, {
       method: "PUT",
-      body: JSON.stringify([{ key, value, ...cloudflareOptions }]),
+      body: JSON.stringify([{ key: r(key), value, ...cloudflareOptions }]),
     });
   };
 
   const removeItem = async (key: string) => {
-    await kvFetch(`/values/${key}`, { method: "DELETE" });
+    await kvFetch(`/values/${r(key)}`, { method: "DELETE" });
   };
 
   const getKeys = async (base?: string) => {

--- a/src/drivers/cloudflare-kv-http.ts
+++ b/src/drivers/cloudflare-kv-http.ts
@@ -171,8 +171,8 @@ export default defineDriver<KVHTTPOptions>((opts) => {
     options: TransactionOptions
   ) => {
     const cloudflareOptions = defu(
-      options.cloudflareKvHttp,
-      options.ttl
+      options?.cloudflareKvHttp,
+      options?.ttl
         ? { expiration_ttl: options.ttl }
         : opts.ttl
         ? { expiration_ttl: opts.ttl }

--- a/src/drivers/cloudflare-kv-http.ts
+++ b/src/drivers/cloudflare-kv-http.ts
@@ -180,7 +180,7 @@ export default defineDriver<KVHTTPOptions>((opts) => {
     );
     await kvFetch(`/bulk`, {
       method: "PUT",
-      body: JSON.stringify([{ key: r(key), value, ...cloudflareOptions }]),
+      body: JSON.stringify([{ ...cloudflareOptions, key: r(key), value }]),
     });
   };
 

--- a/src/drivers/cloudflare-r2-binding.ts
+++ b/src/drivers/cloudflare-r2-binding.ts
@@ -43,22 +43,22 @@ export default defineDriver((opts: CloudflareR2Options) => {
     getItem(key, topts) {
       key = r(key);
       const binding = getBinding(opts.binding);
-      return binding.get(key, topts).then((r) => r?.text());
+      return binding.get(key, topts as any).then((r: any) => r?.text());
     },
     getItemRaw(key, topts) {
       key = r(key);
       const binding = getBinding(opts.binding);
-      return binding.get(key, topts).then((r) => r?.arrayBuffer());
+      return binding.get(key, topts as any).then((r: any) => r?.arrayBuffer());
     },
     async setItem(key, value, topts) {
       key = r(key);
       const binding = getBinding(opts.binding);
-      await binding.put(key, value, topts);
+      await binding.put(key, value, topts as any);
     },
     async setItemRaw(key, value, topts) {
       key = r(key);
       const binding = getBinding(opts.binding);
-      await binding.put(key, value, topts);
+      await binding.put(key, value, topts as any);
     },
     async removeItem(key) {
       key = r(key);

--- a/src/drivers/http.ts
+++ b/src/drivers/http.ts
@@ -21,7 +21,7 @@ export default defineDriver((opts: HTTPOptions) => {
     hasItem(key, topts) {
       return _fetch(r(key), {
         method: "HEAD",
-        headers: { ...opts.headers, ...topts.headers },
+        headers: { ...opts.headers, ...topts?.headers },
       })
         .then(() => true)
         .catch(() => false);
@@ -37,7 +37,7 @@ export default defineDriver((opts: HTTPOptions) => {
         headers: {
           accept: "application/octet-stream",
           ...opts.headers,
-          ...topts.headers,
+          ...topts?.headers,
         },
       });
       return value;
@@ -45,7 +45,7 @@ export default defineDriver((opts: HTTPOptions) => {
     async getMeta(key, topts) {
       const res = await _fetch.raw(r(key), {
         method: "HEAD",
-        headers: { ...opts.headers, ...topts.headers },
+        headers: { ...opts.headers, ...topts?.headers },
       });
       let mtime = undefined;
       const _lastModified = res.headers.get("last-modified");
@@ -71,26 +71,26 @@ export default defineDriver((opts: HTTPOptions) => {
         headers: {
           "content-type": "application/octet-stream",
           ...opts.headers,
-          ...topts.headers,
+          ...topts?.headers,
         },
       });
     },
     async removeItem(key, topts) {
       await _fetch(r(key), {
         method: "DELETE",
-        headers: { ...opts.headers, ...topts.headers },
+        headers: { ...opts.headers, ...topts?.headers },
       });
     },
     async getKeys(base, topts) {
       const value = await _fetch(rBase(base), {
-        headers: { ...opts.headers, ...topts.headers },
+        headers: { ...opts.headers, ...topts?.headers },
       });
       return Array.isArray(value) ? value : [];
     },
     async clear(base, topts) {
       await _fetch(rBase(base), {
         method: "DELETE",
-        headers: { ...opts.headers, ...topts.headers },
+        headers: { ...opts.headers, ...topts?.headers },
       });
     },
   };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,6 @@
+import { CloudflareKvBindingSetItemOptions } from "./drivers/cloudflare-kv-binding";
+import { CloudflareKvHttpSetItemOptions } from "./drivers/cloudflare-kv-http";
+
 export type StorageValue = null | string | number | boolean | object;
 export type WatchEvent = "update" | "remove";
 export type WatchCallback = (event: WatchEvent, key: string) => any;
@@ -14,7 +17,11 @@ export interface StorageMeta {
   [key: string]: StorageValue | Date | undefined;
 }
 
-export type TransactionOptions = Record<string, any>;
+export type TransactionOptions = {
+  cloudflareKvBinding?: CloudflareKvBindingSetItemOptions;
+  cloudflareKvHttp?: CloudflareKvHttpSetItemOptions;
+  ttl?: number;
+} & Record<string, unknown>;
 
 export interface Driver {
   name?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,7 +21,7 @@ export type TransactionOptions = {
   cloudflareKvBinding?: CloudflareKvBindingSetItemOptions;
   cloudflareKvHttp?: CloudflareKvHttpSetItemOptions;
   ttl?: number;
-} & Record<string, unknown>;
+} & Record<string, any>;
 
 export interface Driver {
   name?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,11 +17,13 @@ export interface StorageMeta {
   [key: string]: StorageValue | Date | undefined;
 }
 
-export type TransactionOptions = {
-  cloudflareKvBinding?: CloudflareKvBindingSetItemOptions;
-  cloudflareKvHttp?: CloudflareKvHttpSetItemOptions;
-  ttl?: number;
-} & Record<string, any>;
+export type TransactionOptions =
+  | ({
+      cloudflareKvBinding?: CloudflareKvBindingSetItemOptions;
+      cloudflareKvHttp?: CloudflareKvHttpSetItemOptions;
+      ttl?: number;
+    } & Record<string, any>)
+  | undefined;
 
 export interface Driver {
   name?: string;

--- a/test/drivers/cloudflare-kv-http.test.ts
+++ b/test/drivers/cloudflare-kv-http.test.ts
@@ -18,8 +18,8 @@ const server = setupServer(
     }
     return res(
       ctx.status(200),
-      ctx.set("content-type", "application/octet-stream"),
-      ctx.body(store[key])
+      ctx.set("content-type", "application/json"),
+      ctx.json(store[key])
     );
   }),
 
@@ -31,9 +31,13 @@ const server = setupServer(
     return res(ctx.status(200), ctx.json({ success: true }));
   }),
 
-  rest.put(`${baseURL}/values/:key`, async (req, res, ctx) => {
-    const key = req.params.key as string;
-    store[key] = await req.text();
+  rest.put(`${baseURL}/bulk`, async (req, res, ctx) => {
+    const items = (await req.json()) as Record<string, any>[];
+    if (!items) return res(ctx.status(404), ctx.json(null));
+    for (const item of items) {
+      const { key, value } = item;
+      store[key] = value;
+    }
     return res(ctx.status(204), ctx.json(null));
   }),
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
Resolves https://github.com/unjs/unstorage/issues/32

First part of https://github.com/unjs/unstorage/pull/236

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

This PR allows the ability to pass options to the setItem method while using the cloudflare driver : 

```ts
await storage.setItem("key", "value", 
{ 
  expiration: 1578435000, 
  expiration_ttl: 300, // http driver
  expirationTtl: 300, // binding driver
  base64: false,
  metadata: { someMetadataKey: "someMetadataValue" }
});
```

- implements the cloudflare options such as metadata, expiring keys, etc. 
	- Forward the 3rd argument (options) to the `cloudflare-kv-binding`and `cloudflare-kv-http` drivers `setItem` method.
	- Changes the put implementation of the `cloudflare-kv-http` to use the bulk API ([to support all options](https://developers.cloudflare.com/api/operations/workers-kv-namespace-write-multiple-key-value-pairs)). 

## Options "API design"

For now I'm leverage the 3rd argument of the setItem method, but I was thinking that we could require users to pass them nested under a key (`{ cloudflare: {} }`), or use a 4th argument, in-case we want to keep the 3rd argument open for unstorage specific options... Thoughts ?

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.