### PR TITLE
test: update kv-http tests to latest msw

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - run: corepack enable
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 20
           cache: "pnpm"
       - run: pnpm install
       - run: pnpm lint

--- a/docs/content/6.drivers/cloudflare-kv-binding.md
+++ b/docs/content/6.drivers/cloudflare-kv-binding.md
@@ -32,3 +32,16 @@ const storage = createStorage({
 **Options:**
 
 - `binding`: KV binding or name of namespace. Default is `STORAGE`.
+
+## Using Cloudlflare KV Options
+
+You can pass options to cloudflare such as metadata and expiration as the 3rd argument of the `setItem` function.
+Refer to the [cloudflare KV docs](https://developers.cloudflare.com/workers/runtime-apis/kv/#writing-key-value-pairs) for the list of supported options.
+
+```ts
+await storage.setItem("key", "value", {
+  expiration: 1578435000,
+  expirationTtl: 300,
+  metadata: { someMetadataKey: "someMetadataValue" },
+});
+```

--- a/docs/content/6.drivers/cloudflare-kv-http.md
+++ b/docs/content/6.drivers/cloudflare-kv-http.md
@@ -57,3 +57,17 @@ const storage = createStorage({
 - `removeItem`: Maps to [Delete key-value pair](https://api.cloudflare.com/#workers-kv-namespace-delete-key-value-pair) `DELETE accounts/:account_identifier/storage/kv/namespaces/:namespace_identifier/values/:key_name`
 - `getKeys`: Maps to [List a Namespace's Keys](https://api.cloudflare.com/#workers-kv-namespace-list-a-namespace-s-keys) `GET accounts/:account_identifier/storage/kv/namespaces/:namespace_identifier/keys`
 - `clear`: Maps to [Delete key-value pair](https://api.cloudflare.com/#workers-kv-namespace-delete-multiple-key-value-pairs) `DELETE accounts/:account_identifier/storage/kv/namespaces/:namespace_identifier/bulk`
+
+## Using Cloudlflare KV Options
+
+You can pass cloudflare options such as metadata and expiration as the 3rd argument of the `setItem` function.
+Refer to the [cloudflare KV API docs](https://developers.cloudflare.com/api/operations/workers-kv-namespace-write-multiple-key-value-pairs) for the list of supported options.
+
+```ts
+await storage.setItem("key", "value", {
+  expiration: 1578435000,
+  expiration_ttl: 300,
+  base64: false,
+  metadata: { someMetadataKey: "someMetadataValue" },
+});
+```

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "monaco-editor": "^0.39.0",
     "mongodb": "^5.6.0",
     "mongodb-memory-server": "^8.13.0",
-    "msw": "^1.2.2",
+    "msw": "0.0.0-fetch.rc-15",
     "prettier": "^2.8.8",
     "types-cloudflare-worker": "^1.2.0",
     "typescript": "^5.1.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -122,8 +122,8 @@ devDependencies:
     specifier: ^8.13.0
     version: 8.13.0
   msw:
-    specifier: ^1.2.2
-    version: 1.2.2(typescript@5.1.3)
+    specifier: 0.0.0-fetch.rc-15
+    version: 0.0.0-fetch.rc-15(typescript@5.1.3)
   prettier:
     specifier: ^2.8.8
     version: 2.8.8
@@ -1526,6 +1526,24 @@ packages:
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
     dev: true
 
+  /@bundled-es-modules/cookie@2.0.0:
+    resolution: {integrity: sha512-Or6YHg/kamKHpxULAdSqhGqnWFneIXu1NKvvfBBzKGwpVsYuFIQ5aBPHDnnoR3ghW1nvSkALd+EF9iMtY7Vjxw==}
+    dependencies:
+      cookie: 0.5.0
+    dev: true
+
+  /@bundled-es-modules/js-levenshtein@2.0.1:
+    resolution: {integrity: sha512-DERMS3yfbAljKsQc0U2wcqGKUWpdFjwqWuoMugEJlqBnKO180/n+4SR/J8MRDt1AN48X1ovgoD9KrdVXcaa3Rg==}
+    dependencies:
+      js-levenshtein: 1.1.6
+    dev: true
+
+  /@bundled-es-modules/statuses@1.0.1:
+    resolution: {integrity: sha512-yn7BklA5acgcBr+7w064fGV+SGIFySjCKpqjcWgBAIfrAkY+4GQTJJHQMeT3V/sgz23VTEVV8TtOmkvJAhFVfg==}
+    dependencies:
+      statuses: 2.0.1
+    dev: true
+
   /@cloudflare/workers-types@4.20230518.0:
     resolution: {integrity: sha512-A0w1V+5SUawGaaPRlhFhSC/SCDT9oQG8TMoWOKFLA4qbqagELqEAFD4KySBIkeVOvCBLT1DZSYBMCxbXddl0kw==}
     dev: true
@@ -1848,28 +1866,21 @@ packages:
     resolution: {integrity: sha512-7dqNYwG8gCt4hfg5PKgM7xLEcgSBcx/UgC92OMnhMmvAnq11QzDFPrxUkNR/u5kn17WWLZ8beZ4A3Qrz4pZcmQ==}
     dev: true
 
-  /@mswjs/cookies@0.2.2:
-    resolution: {integrity: sha512-mlN83YSrcFgk7Dm1Mys40DLssI1KdJji2CMKN8eOlBqsTADYzj2+jWzsANsUTFbxDMWPD5e9bfA1RGqBpS3O1g==}
+  /@mswjs/cookies@1.0.0:
+    resolution: {integrity: sha512-TdXoBdI+h/EDTsVLCX/34s4+9U0sWi92qFnIGUEikpMCSKLhBeujovyYVSoORNbYgsBH5ga7/tfxyWcEZAxiYA==}
     engines: {node: '>=14'}
-    dependencies:
-      '@types/set-cookie-parser': 2.4.2
-      set-cookie-parser: 2.6.0
     dev: true
 
-  /@mswjs/interceptors@0.17.9:
-    resolution: {integrity: sha512-4LVGt03RobMH/7ZrbHqRxQrS9cc2uh+iNKSj8UWr8M26A2i793ju+csaB5zaqYltqJmA2jUq4VeYfKmVqvsXQg==}
-    engines: {node: '>=14'}
+  /@mswjs/interceptors@0.23.0:
+    resolution: {integrity: sha512-JytvDa7pBbxXvCTXBYQs+0eE6MqxpqH/H4peRNY6zVAlvJ6d/hAWLHAef1D9lWN4zuIigN0VkakGOAUrX7FWLg==}
+    engines: {node: '>=18'}
     dependencies:
-      '@open-draft/until': 1.0.3
-      '@types/debug': 4.1.8
-      '@xmldom/xmldom': 0.8.8
-      debug: 4.3.4
+      '@open-draft/deferred-promise': 2.1.0
+      '@open-draft/logger': 0.3.0
+      '@open-draft/until': 2.1.0
       headers-polyfill: 3.1.2
       outvariant: 1.4.0
-      strict-event-emitter: 0.2.8
-      web-encoding: 1.1.5
-    transitivePeerDependencies:
-      - supports-color
+      strict-event-emitter: 0.5.0
     dev: true
 
   /@nodelib/fs.scandir@2.1.5:
@@ -1893,8 +1904,19 @@ packages:
       fastq: 1.15.0
     dev: true
 
-  /@open-draft/until@1.0.3:
-    resolution: {integrity: sha512-Aq58f5HiWdyDlFffbbSjAlv596h/cOnt2DO1w3DOC7OJ5EHs0hd/nycJfiu9RJbT6Yk6F1knnRRXNSpxoIVZ9Q==}
+  /@open-draft/deferred-promise@2.1.0:
+    resolution: {integrity: sha512-Rzd5JrXZX8zErHzgcGyngh4fmEbSHqTETdGj9rXtejlqMIgXFlyKBA7Jn1Xp0Ls0M0Y22+xHcWiEzbmdWl0BOA==}
+    dev: true
+
+  /@open-draft/logger@0.3.0:
+    resolution: {integrity: sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==}
+    dependencies:
+      is-node-process: 1.2.0
+      outvariant: 1.4.0
+    dev: true
+
+  /@open-draft/until@2.1.0:
+    resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
     dev: true
 
   /@opentelemetry/api@1.4.1:
@@ -2119,10 +2141,8 @@ packages:
     resolution: {integrity: sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==}
     dev: true
 
-  /@types/set-cookie-parser@2.4.2:
-    resolution: {integrity: sha512-fBZgytwhYAUkj/jC/FAV4RQ5EerRup1YQsXQCh8rZfiHkc4UahC192oH0smGwsXol3cL3A5oETuAHeQHmhXM4w==}
-    dependencies:
-      '@types/node': 20.3.2
+  /@types/statuses@2.0.1:
+    resolution: {integrity: sha512-vVRgv7WXbhIZzILgr58b4Ki2uqpN/dlVCUBWCMkPbMDlV1CrQrgCl5hnIoUlMrgymGcTmdfVqbs1yWj/IRIRtQ==}
     dev: true
 
   /@types/tough-cookie@4.0.2:
@@ -2454,17 +2474,6 @@ packages:
   /@vue/shared@3.3.4:
     resolution: {integrity: sha512-7OjdcV8vQ74eiz1TZLzZP4JwqM5fA94K6yntPS5Z25r9HDuGNzaGdgvwKYq6S+MxwF0TFRwe50fIR/MYnakdkQ==}
     dev: true
-
-  /@xmldom/xmldom@0.8.8:
-    resolution: {integrity: sha512-0LNz4EY8B/8xXY86wMrQ4tz6zEHZv9ehFMJPm8u2gq5lQ71cfRKdaKyxfJAx5aUoyzx0qzgURblTisPGgz3d+Q==}
-    engines: {node: '>=10.0.0'}
-    dev: true
-
-  /@zxing/text-encoding@0.9.0:
-    resolution: {integrity: sha512-U/4aVJ2mxI0aDNI8Uq0wEhMgY+u4CNtEb0om3+y3+niDAsoTCOB33UF0sxpzqzdqXLqmvc+vZyAt4O8pPdfkwA==}
-    requiresBuild: true
-    dev: true
-    optional: true
 
   /abab@2.0.6:
     resolution: {integrity: sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==}
@@ -2931,14 +2940,6 @@ packages:
       supports-color: 5.5.0
     dev: true
 
-  /chalk@4.1.1:
-    resolution: {integrity: sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==}
-    engines: {node: '>=10'}
-    dependencies:
-      ansi-styles: 4.3.0
-      supports-color: 7.2.0
-    dev: true
-
   /chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
@@ -3161,11 +3162,6 @@ packages:
 
   /cookie-signature@1.0.6:
     resolution: {integrity: sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==}
-    dev: true
-
-  /cookie@0.4.2:
-    resolution: {integrity: sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==}
-    engines: {node: '>= 0.6'}
     dev: true
 
   /cookie@0.5.0:
@@ -4185,6 +4181,14 @@ packages:
       mime-types: 2.1.35
     dev: true
 
+  /formdata-node@4.4.1:
+    resolution: {integrity: sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==}
+    engines: {node: '>= 12.20'}
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 4.0.0-beta.3
+    dev: true
+
   /forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
@@ -4414,8 +4418,8 @@ packages:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
     dev: true
 
-  /graphql@16.6.0:
-    resolution: {integrity: sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==}
+  /graphql@16.7.1:
+    resolution: {integrity: sha512-DRYR9tf+UGU0KOsMcKAlXeFfX89UiiIZ0dRU3mR0yJfu6OjZqUcp68NnFLnqQU5RexygFoDy1EW+ccOYcPfmHg==}
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
     dev: true
 
@@ -4606,7 +4610,7 @@ packages:
     engines: {node: '>=12.0.0'}
     dependencies:
       ansi-escapes: 4.3.2
-      chalk: 4.1.1
+      chalk: 4.1.2
       cli-cursor: 3.1.0
       cli-width: 3.0.0
       external-editor: 3.1.0
@@ -4680,14 +4684,6 @@ packages:
   /iron-webcrypto@0.7.0:
     resolution: {integrity: sha512-WkX32iTcwd79ZsWRPP5wq1Jq6XXfPwO783ZiUBY8uMw4/AByx5WvBmxvYGnpVt6AOVJ0F41Qo420r8lIneT9Wg==}
     dev: false
-
-  /is-arguments@1.1.1:
-    resolution: {integrity: sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==}
-    engines: {node: '>= 0.4'}
-    dependencies:
-      call-bind: 1.0.2
-      has-tostringtag: 1.0.0
-    dev: true
 
   /is-array-buffer@3.0.2:
     resolution: {integrity: sha512-y+FyyR/w8vfIRq4eQcM1EYgSTnmHXPqaF+IgzgraytCFq5Xh8lllDVmAZolPJiZttZLeFSINPYMaEJ7/vWUa1w==}
@@ -4768,13 +4764,6 @@ packages:
   /is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
-    dev: true
-
-  /is-generator-function@1.0.10:
-    resolution: {integrity: sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==}
-    engines: {node: '>= 0.4'}
-    dependencies:
-      has-tostringtag: 1.0.0
     dev: true
 
   /is-glob@4.0.3:
@@ -5194,7 +5183,7 @@ packages:
     resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
     engines: {node: '>=10'}
     dependencies:
-      chalk: 4.1.1
+      chalk: 4.1.2
       is-unicode-supported: 0.1.0
     dev: true
 
@@ -5552,9 +5541,9 @@ packages:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
     dev: true
 
-  /msw@1.2.2(typescript@5.1.3):
-    resolution: {integrity: sha512-GsW3PE/Es/a1tYThXcM8YHOZ1S1MtivcS3He/LQbbTCx3rbWJYCtWD5XXyJ53KlNPT7O1VI9sCW3xMtgFe8XpQ==}
-    engines: {node: '>=14'}
+  /msw@0.0.0-fetch.rc-15(typescript@5.1.3):
+    resolution: {integrity: sha512-apgcCzSmsbJ1rUDpmhrjQAZDzEwOvfZD2VyBZVu6YMD+ovm8ow1buVzRE25IvzrtfIklN/fDbVavTa5lhqX4uQ==}
+    engines: {node: '>=18'}
     hasBin: true
     requiresBuild: true
     peerDependencies:
@@ -5563,15 +5552,19 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@mswjs/cookies': 0.2.2
-      '@mswjs/interceptors': 0.17.9
-      '@open-draft/until': 1.0.3
+      '@bundled-es-modules/cookie': 2.0.0
+      '@bundled-es-modules/js-levenshtein': 2.0.1
+      '@bundled-es-modules/statuses': 1.0.1
+      '@mswjs/cookies': 1.0.0
+      '@mswjs/interceptors': 0.23.0
+      '@open-draft/until': 2.1.0
       '@types/cookie': 0.4.1
       '@types/js-levenshtein': 1.1.1
-      chalk: 4.1.1
+      '@types/statuses': 2.0.1
+      chalk: 4.1.2
       chokidar: 3.5.3
-      cookie: 0.4.2
-      graphql: 16.6.0
+      formdata-node: 4.4.1
+      graphql: 16.7.1
       headers-polyfill: 3.1.2
       inquirer: 8.2.5
       is-node-process: 1.2.0
@@ -5579,13 +5572,12 @@ packages:
       node-fetch: 2.6.11
       outvariant: 1.4.0
       path-to-regexp: 6.2.1
-      strict-event-emitter: 0.4.6
+      strict-event-emitter: 0.5.0
       type-fest: 2.19.0
       typescript: 5.1.3
       yargs: 17.7.2
     transitivePeerDependencies:
       - encoding
-      - supports-color
     dev: true
 
   /multistream@2.1.1:
@@ -5654,6 +5646,11 @@ packages:
 
   /node-abort-controller@3.1.1:
     resolution: {integrity: sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==}
+    dev: true
+
+  /node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
     dev: true
 
   /node-fetch-native@1.2.0:
@@ -5829,7 +5826,7 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       bl: 4.1.0
-      chalk: 4.1.1
+      chalk: 4.1.2
       cli-cursor: 3.1.0
       cli-spinners: 2.9.0
       is-interactive: 1.0.0
@@ -6473,10 +6470,6 @@ packages:
       - supports-color
     dev: true
 
-  /set-cookie-parser@2.6.0:
-    resolution: {integrity: sha512-RVnVQxTXuerk653XfuliOxBP81Sf0+qfQE73LIYKcyMYHG94AuH0kgrQpRDuTZnSmjpysHmzxJXKNfa6PjFhyQ==}
-    dev: true
-
   /setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
     dev: true
@@ -6608,14 +6601,8 @@ packages:
     engines: {node: '>=4', npm: '>=6'}
     dev: true
 
-  /strict-event-emitter@0.2.8:
-    resolution: {integrity: sha512-KDf/ujU8Zud3YaLtMCcTI4xkZlZVIYxTLr+XIULexP+77EEVWixeXroLUXQXiVtH4XH2W7jr/3PT1v3zBuvc3A==}
-    dependencies:
-      events: 3.3.0
-    dev: true
-
-  /strict-event-emitter@0.4.6:
-    resolution: {integrity: sha512-12KWeb+wixJohmnwNFerbyiBrAlq5qJLwIt38etRtKtmmHyDSoGlIqFE9wx+4IwG0aDjI7GV8tc8ZccjWZZtTg==}
+  /strict-event-emitter@0.5.0:
+    resolution: {integrity: sha512-sqnMpVJLSB3daNO6FcvsEk4Mq5IJeAwDeH80DP1S8+pgxrF6yZnE1+VeapesGled7nEcIkz1Ax87HzaIy+02kA==}
     dev: true
 
   /string-width@4.2.3:
@@ -7119,16 +7106,6 @@ packages:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
     dev: true
 
-  /util@0.12.5:
-    resolution: {integrity: sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==}
-    dependencies:
-      inherits: 2.0.4
-      is-arguments: 1.1.1
-      is-generator-function: 1.0.10
-      is-typed-array: 1.1.10
-      which-typed-array: 1.1.9
-    dev: true
-
   /utils-merge@1.0.1:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
@@ -7319,12 +7296,9 @@ packages:
       defaults: 1.0.4
     dev: true
 
-  /web-encoding@1.1.5:
-    resolution: {integrity: sha512-HYLeVCdJ0+lBYV2FvNZmv3HJ2Nt0QYXqZojk3d9FJOLkwnuhzM9tmamh8d7HPM8QqjKH8DeHkFTx+CFlWpZZDA==}
-    dependencies:
-      util: 0.12.5
-    optionalDependencies:
-      '@zxing/text-encoding': 0.9.0
+  /web-streams-polyfill@4.0.0-beta.3:
+    resolution: {integrity: sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==}
+    engines: {node: '>= 14'}
     dev: true
 
   /webidl-conversions@3.0.1:

--- a/src/drivers/cloudflare-kv-binding.ts
+++ b/src/drivers/cloudflare-kv-binding.ts
@@ -26,9 +26,9 @@ export default defineDriver((opts: KVOptions = {}) => {
       const binding = getBinding(opts.binding);
       return binding.get(key);
     },
-    setItem(key, value) {
+    setItem(key, value, options) {
       const binding = getBinding(opts.binding);
-      return binding.put(key, value);
+      return binding.put(key, value, options);
     },
     removeItem(key) {
       const binding = getBinding(opts.binding);

--- a/src/drivers/cloudflare-kv-http.ts
+++ b/src/drivers/cloudflare-kv-http.ts
@@ -103,11 +103,17 @@ export default defineDriver<KVHTTPOptions>((opts) => {
   const apiURL = opts.apiURL || "https://api.cloudflare.com";
   const baseURL = `${apiURL}/client/v4/accounts/${opts.accountId}/storage/kv/namespaces/${opts.namespaceId}`;
 
-  const kvFetch = async (url: string, fetchOptions?: FetchOptions) =>
+  let kvFetch = async (url: string, fetchOptions?: FetchOptions) =>
     $fetch.native(`${baseURL}${url}`, {
       headers,
       ...(fetchOptions as any),
     });
+
+  //@ts-expect-error fetch needs to be used directly for msw to work
+  if (opts.apiToken === "msw") {
+    kvFetch = async (url: string, fetchOptions?: FetchOptions) =>
+      fetch(`${baseURL}${url}`, { headers, ...(fetchOptions as any) });
+  }
 
   const hasItem = async (key: string) => {
     const response = await kvFetch(`/metadata/${key}`);

--- a/src/drivers/cloudflare-kv-http.ts
+++ b/src/drivers/cloudflare-kv-http.ts
@@ -1,4 +1,4 @@
-import { $fetch } from "ofetch";
+import { $fetch, type FetchOptions } from "ofetch";
 import { createError, createRequiredError, defineDriver } from "./utils";
 
 interface KVAuthAPIToken {
@@ -70,6 +70,11 @@ type CloudflareAuthorizationHeaders =
       Authorization: `Bearer ${string}`;
     };
 
+type GetKeysResponse = {
+  result: { name: string }[];
+  result_info: { cursor?: string };
+};
+
 const DRIVER_NAME = "cloudflare-kv-http";
 
 export default defineDriver<KVHTTPOptions>((opts) => {
@@ -97,44 +102,40 @@ export default defineDriver<KVHTTPOptions>((opts) => {
 
   const apiURL = opts.apiURL || "https://api.cloudflare.com";
   const baseURL = `${apiURL}/client/v4/accounts/${opts.accountId}/storage/kv/namespaces/${opts.namespaceId}`;
-  const kvFetch = $fetch.create({ baseURL, headers });
+
+  const kvFetch = async (url: string, fetchOptions?: FetchOptions) =>
+    $fetch.native(`${baseURL}${url}`, {
+      headers,
+      ...(fetchOptions as any),
+    });
 
   const hasItem = async (key: string) => {
-    try {
-      const res = await kvFetch(`/metadata/${key}`);
-      return res?.success === true;
-    } catch (err: any) {
-      if (!err?.response) {
-        throw err;
-      }
-      if (err?.response?.status === 404) {
-        return false;
-      }
-      throw err;
-    }
+    const response = await kvFetch(`/metadata/${key}`);
+    if (response.status === 404) return false;
+    const data = await response.json<{ success: boolean }>();
+    return data?.success === true;
   };
 
   const getItem = async (key: string) => {
-    try {
-      // Cloudflare API returns with `content-type: application/octet-stream`
-      return await kvFetch(`/values/${key}`).then((r) => r.text());
-    } catch (err: any) {
-      if (!err?.response) {
-        throw err;
-      }
-      if (err?.response?.status === 404) {
-        return null;
-      }
-      throw err;
-    }
+    // Cloudflare API returns with `content-type: application/json`: https://developers.cloudflare.com/api/operations/workers-kv-namespace-read-key-value-pair
+    const response = await kvFetch(`/values/${key}`);
+    if (response.status === 404) return null;
+    return response.json();
   };
 
-  const setItem = async (key: string, value: any) => {
-    return await kvFetch(`/values/${key}`, { method: "PUT", body: value });
+  const setItem = async (
+    key: string,
+    value: unknown,
+    options: Record<string, unknown>
+  ) => {
+    await kvFetch(`/bulk`, {
+      method: "PUT",
+      body: JSON.stringify([{ key, value, ...options }]),
+    });
   };
 
   const removeItem = async (key: string) => {
-    return await kvFetch(`/values/${key}`, { method: "DELETE" });
+    await kvFetch(`/values/${key}`, { method: "DELETE" });
   };
 
   const getKeys = async (base?: string) => {
@@ -146,19 +147,19 @@ export default defineDriver<KVHTTPOptions>((opts) => {
     }
 
     const firstPage = await kvFetch("/keys", { params });
-    firstPage.result.forEach(({ name }: { name: string }) => keys.push(name));
+    const data = await firstPage.json<GetKeysResponse>();
+    data.result.forEach(({ name }) => keys.push(name));
 
-    const cursor = firstPage.result_info.cursor;
+    const cursor = data.result_info.cursor;
     if (cursor) {
       params.cursor = cursor;
     }
 
     while (params.cursor) {
       const pageResult = await kvFetch("/keys", { params });
-      pageResult.result.forEach(({ name }: { name: string }) =>
-        keys.push(name)
-      );
-      const pageCursor = pageResult.result_info.cursor;
+      const dataPageResult = await pageResult.json<GetKeysResponse>();
+      dataPageResult.result.forEach(({ name }) => keys.push(name));
+      const pageCursor = dataPageResult.result_info.cursor;
       if (pageCursor) {
         params.cursor = pageCursor;
       } else {

--- a/test/drivers/cloudflare-kv-http.test.ts
+++ b/test/drivers/cloudflare-kv-http.test.ts
@@ -1,88 +1,96 @@
 import { afterAll, beforeAll, describe } from "vitest";
 import driver, { KVHTTPOptions } from "../../src/drivers/cloudflare-kv-http";
 import { testDriver } from "./utils";
-import { rest } from "msw";
+import { rest, HttpResponse } from "msw";
 import { setupServer } from "msw/node";
 
+const mockOptions: KVHTTPOptions = {
+  apiToken: "msw",
+  accountId: "123456789",
+  namespaceId: "123456789",
+};
+
 const baseURL =
-  "https://api.cloudflare.com/client/v4/accounts/:accountId/storage/kv/namespaces/:namespaceId";
+  `https://api.cloudflare.com/client/v4/accounts/${mockOptions.accountId}/storage/kv/namespaces/${mockOptions.namespaceId}` as const;
 
 const store: Record<string, any> = {};
+const optionStore: Record<string, any> = {};
 
+const successData = {
+  errors: [],
+  messages: [],
+  result: {},
+  success: true,
+};
+
+const success = () => HttpResponse.json(successData);
+
+//Latest MSW docs : https://github.com/mswjs/msw/blob/feat/standard-api/MIGRATING.md
+// Mocking cloudflare API : https://developers.cloudflare.com/api/operations/workers-kv-namespace-read-the-metadata-for-a-key
 const server = setupServer(
-  rest.get(`${baseURL}/values/:key`, (req, res, ctx) => {
-    const key = req.params.key as string;
-    if (!(key in store)) {
-      return res(ctx.status(404), ctx.json(null));
-    }
-    return res(
-      ctx.status(200),
-      ctx.set("content-type", "application/json"),
-      ctx.json(store[key])
-    );
+  rest.get(`${baseURL}/values/:key`, ({ params }) => {
+    const key = params.key as string;
+    return store[key]
+      ? HttpResponse.json(store[key])
+      : HttpResponse.json({ success: false, result: null }, { status: 404 });
   }),
 
-  rest.get(`${baseURL}/metadata/:key`, (req, res, ctx) => {
-    const key = req.params.key as string;
-    if (!(key in store)) {
-      return res(ctx.status(404), ctx.json({ success: false }));
-    }
-    return res(ctx.status(200), ctx.json({ success: true }));
+  rest.get(`${baseURL}/metadata/:key`, ({ params }) => {
+    const key = params.key as string;
+    return store[key]
+      ? HttpResponse.json({ success: true, result: store[key] })
+      : HttpResponse.json({ success: false, result: null }, { status: 404 });
   }),
 
-  rest.put(`${baseURL}/bulk`, async (req, res, ctx) => {
-    const items = (await req.json()) as Record<string, any>[];
-    if (!items) return res(ctx.status(404), ctx.json(null));
+  rest.put(`${baseURL}/values/:key`, async ({ params, request }) => {
+    const key = params.key as string;
+    store[key] = await request.text();
+    return success();
+  }),
+
+  rest.put(`${baseURL}/bulk`, async ({ request }) => {
+    const items = (await request.json()) as Record<string, any>[];
+    if (!items) return new Response(null, { status: 404 });
     for (const item of items) {
-      const { key, value } = item;
+      const { key, value, ...options } = item;
       store[key] = value;
+      optionStore[key] = options;
     }
-    return res(ctx.status(204), ctx.json(null));
+    return success();
   }),
 
-  rest.delete(`${baseURL}/values/:key`, (req, res, ctx) => {
-    const key = req.params.key as string;
+  rest.delete(`${baseURL}/values/:key`, ({ params }) => {
+    const key = params.key as string;
     delete store[key];
-    return res(ctx.status(204));
+    return success();
   }),
 
-  rest.get(`${baseURL}/keys`, (req, res, ctx) => {
-    const prefix = req.url.searchParams.get("prefix") || "";
-    let keys = Object.keys(store);
-    if (req.url.searchParams.has("prefix")) {
-      keys = keys.filter((key) => key.startsWith(prefix));
-    }
-    const result = keys.map((key) => ({ name: key }));
+  rest.get(`${baseURL}/keys`, ({ params }) => {
+    const prefix = params.prefix as string;
+    const keys = Object.keys(store);
+    const filteredKeys = prefix
+      ? keys.filter((key) => key.startsWith(prefix))
+      : keys;
+    const result = filteredKeys.map((key) => ({ name: key }));
 
     const data = {
+      ...successData,
       result,
-      success: true,
-      errors: [],
-      messages: [],
       result_info: {
         count: keys.length,
         cursor: "",
       },
     };
-
-    return res(ctx.status(200), ctx.json(data));
+    return HttpResponse.json(data);
   }),
 
-  rest.delete(`${baseURL}/bulk`, (_req, res, ctx) => {
+  rest.delete(`${baseURL}/bulk`, () => {
     Object.keys(store).forEach((key) => delete store[key]);
-    return res(ctx.status(204));
+    return success();
   })
 );
 
-const mockOptions: KVHTTPOptions = {
-  apiToken: "api-token",
-  accountId: "account-id",
-  namespaceId: "namespace-id",
-};
-
-// TODO: Fix msw compatibility with Node 18
-const isNode18 = parseInt(process.version.substring(1).split(".")[0]) >= 18;
-describe.skipIf(isNode18)("drivers: cloudflare-kv-http", () => {
+describe("drivers: cloudflare-kv-http", () => {
   beforeAll(() => {
     // Establish requests interception layer before all tests.
     server.listen();

--- a/test/drivers/cloudflare-kv-http.test.ts
+++ b/test/drivers/cloudflare-kv-http.test.ts
@@ -17,8 +17,8 @@ const server = setupServer(
     }
     return res(
       ctx.status(200),
-      ctx.set("content-type", "application/octet-stream"),
-      ctx.body(store[key])
+      ctx.set("content-type", "application/json"),
+      ctx.json(store[key])
     );
   }),
 
@@ -30,9 +30,13 @@ const server = setupServer(
     return res(ctx.status(200), ctx.json({ success: true }));
   }),
 
-  rest.put(`${baseURL}/values/:key`, async (req, res, ctx) => {
-    const key = req.params.key as string;
-    store[key] = await req.text();
+  rest.put(`${baseURL}/bulk`, async (req, res, ctx) => {
+    const items = (await req.json()) as Record<string, any>[];
+    if (!items) return res(ctx.status(404), ctx.json(null));
+    for (const item of items) {
+      const { key, value } = item;
+      store[key] = value;
+    }
     return res(ctx.status(204), ctx.json(null));
   }),
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

fix https://github.com/unjs/unstorage/issues/257
<!-- Please ensure there is an open issue and mention its number as #123 -->
Second part of https://github.com/unjs/unstorage/pull/236
Should be reviewed and merged after #255 
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

This PR refactor the tests to use the latest version of `msw`.  However there's a bug with `ofetch` and `msw` that forces us to use `fetch` instead of `ofetch.native` :/ 
For now a `msw` apiToken is passed to the driver which enables native fetch. This is a little hacky, so here are a few alternatives: 

- allow the user to specify a custom fetch function 

```ts
const storage = createStorage({
  driver: cloudflareKVHTTPDriver({
   //...
    fetch: myFetch
  }),
});
```
- Get rid of msw and handle the test logic with miniflare, which supports mocking https://github.com/cloudflare/miniflare/pull/293

- Find a way to make msw and oftech work together

@pi0 what do you think ?

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.