### PR TITLE
fix: return `undefined` instead of `null` for non existing keys

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,6 @@
 {
   "extends": ["eslint-config-unjs"],
   "rules": {
-    "unicorn/no-null": 0,
     "unicorn/prevent-abbreviations": 0,
     "@typescript-eslint/no-non-null-assertion": 0,
     "unicorn/prefer-string-replace-all": 0

--- a/docs/content/2.usage.md
+++ b/docs/content/2.usage.md
@@ -304,5 +304,5 @@ In [strict mode](https://www.typescriptlang.org/tsconfig#strict), will also retu
 ```ts
 "use strict";
 
-await storage.getItem<string>("k"); // => <string | null>
+await storage.getItem<string>("k"); // => <string | undefined>
 ```

--- a/src/drivers/azure-app-configuration.ts
+++ b/src/drivers/azure-app-configuration.ts
@@ -87,7 +87,7 @@ export default defineDriver((opts: AzureAppConfigurationOptions = {}) => {
         });
         return setting.value;
       } catch {
-        return null;
+        return undefined;
       }
     },
     async setItem(key, value) {

--- a/src/drivers/azure-cosmos.ts
+++ b/src/drivers/azure-cosmos.ts
@@ -96,7 +96,7 @@ export default defineDriver((opts: AzureCosmosOptions) => {
       const item = await (await getCosmosClient())
         .item(key)
         .read<AzureCosmosItem>();
-      return item.resource ? item.resource.value : null;
+      return item.resource ? item.resource.value : undefined;
     },
     async setItem(key, value) {
       const modified = new Date();

--- a/src/drivers/azure-key-vault.ts
+++ b/src/drivers/azure-key-vault.ts
@@ -29,7 +29,11 @@ export default defineDriver((opts: AzureKeyVaultOptions) => {
     if (keyVaultClient) {
       return keyVaultClient;
     }
-    const { vaultName = null, serviceVersion = "7.3", pageSize = 25 } = opts;
+    const {
+      vaultName = undefined,
+      serviceVersion = "7.3",
+      pageSize = 25,
+    } = opts;
     if (!vaultName) {
       throw createRequiredError(DRIVER_NAME, "vaultName");
     }
@@ -58,7 +62,7 @@ export default defineDriver((opts: AzureKeyVaultOptions) => {
         const secret = await getKeyVaultClient().getSecret(encode(key));
         return secret.value;
       } catch {
-        return null;
+        return undefined;
       }
     },
     async setItem(key, value) {

--- a/src/drivers/azure-storage-blob.ts
+++ b/src/drivers/azure-storage-blob.ts
@@ -90,13 +90,15 @@ export default defineDriver((opts: AzureStorageBlobOptions) => {
           .getBlockBlobClient(key)
           .download();
         if (isBrowser) {
-          return blob.blobBody ? await blobToString(await blob.blobBody) : null;
+          return blob.blobBody
+            ? await blobToString(await blob.blobBody)
+            : undefined;
         }
         return blob.readableStreamBody
           ? (await streamToBuffer(blob.readableStreamBody)).toString()
-          : null;
+          : undefined;
       } catch {
-        return null;
+        return undefined;
       }
     },
     async setItem(key, value) {

--- a/src/drivers/azure-storage-table.ts
+++ b/src/drivers/azure-storage-table.ts
@@ -50,12 +50,12 @@ const DRIVER_NAME = "azure-storage-table";
 
 export default defineDriver((opts: AzureStorageTableOptions) => {
   const {
-    accountName = null,
+    accountName = undefined,
     tableName = "unstorage",
     partitionKey = "unstorage",
-    accountKey = null,
-    sasKey = null,
-    connectionString = null,
+    accountKey = undefined,
+    sasKey = undefined,
+    connectionString = undefined,
     pageSize = 1000,
   } = opts;
 
@@ -118,7 +118,7 @@ export default defineDriver((opts: AzureStorageTableOptions) => {
         const entity = await getClient().getEntity(partitionKey, key);
         return entity.unstorageValue;
       } catch {
-        return null;
+        return undefined;
       }
     },
     async setItem(key, value) {

--- a/src/drivers/cloudflare-kv-binding.ts
+++ b/src/drivers/cloudflare-kv-binding.ts
@@ -20,7 +20,8 @@ export default defineDriver((opts: KVOptions = {}) => {
     options: opts,
     async hasItem(key) {
       const binding = getBinding(opts.binding);
-      return (await binding.get(key)) !== null;
+      const value = await binding.get(key);
+      return value !== null && value !== undefined;
     },
     getItem(key) {
       const binding = getBinding(opts.binding);

--- a/src/drivers/cloudflare-kv-http.ts
+++ b/src/drivers/cloudflare-kv-http.ts
@@ -123,7 +123,7 @@ export default defineDriver<KVHTTPOptions>((opts) => {
         throw err;
       }
       if (err?.response?.status === 404) {
-        return null;
+        return undefined;
       }
       throw err;
     }

--- a/src/drivers/github.ts
+++ b/src/drivers/github.ts
@@ -98,7 +98,7 @@ export default defineDriver<GithubOptions>((_opts) => {
       const item = files[key];
 
       if (!item) {
-        return null;
+        return undefined;
       }
 
       if (!item.body) {
@@ -124,7 +124,7 @@ export default defineDriver<GithubOptions>((_opts) => {
     async getMeta(key) {
       await syncFiles();
       const item = files[key as keyof typeof files];
-      return item ? item.meta : null;
+      return item ? item.meta : undefined;
     },
   };
 });

--- a/src/drivers/localstorage.ts
+++ b/src/drivers/localstorage.ts
@@ -36,7 +36,7 @@ export default defineDriver((opts: LocalStorageOptions = {}) => {
       return Object.prototype.hasOwnProperty.call(opts.localStorage!, r(key));
     },
     getItem(key) {
-      return opts.localStorage!.getItem(r(key)) || undefined;
+      return opts.localStorage!.getItem(r(key)) ?? undefined;
     },
     setItem(key, value) {
       return opts.localStorage!.setItem(r(key), value);

--- a/src/drivers/localstorage.ts
+++ b/src/drivers/localstorage.ts
@@ -36,7 +36,7 @@ export default defineDriver((opts: LocalStorageOptions = {}) => {
       return Object.prototype.hasOwnProperty.call(opts.localStorage!, r(key));
     },
     getItem(key) {
-      return opts.localStorage!.getItem(r(key));
+      return opts.localStorage!.getItem(r(key)) || undefined;
     },
     setItem(key, value) {
       return opts.localStorage!.setItem(r(key), value);

--- a/src/drivers/lru-cache.ts
+++ b/src/drivers/lru-cache.ts
@@ -29,10 +29,10 @@ export default defineDriver((opts: LRUDriverOptions = {}) => {
       return cache.has(key);
     },
     getItem(key) {
-      return cache.get(key) || undefined;
+      return cache.get(key) ?? undefined;
     },
     getItemRaw(key) {
-      return cache.get(key) || undefined;
+      return cache.get(key) ?? undefined;
     },
     setItem(key, value) {
       cache.set(key, value);

--- a/src/drivers/lru-cache.ts
+++ b/src/drivers/lru-cache.ts
@@ -29,10 +29,10 @@ export default defineDriver((opts: LRUDriverOptions = {}) => {
       return cache.has(key);
     },
     getItem(key) {
-      return cache.get(key) || null;
+      return cache.get(key) || undefined;
     },
     getItemRaw(key) {
-      return cache.get(key) || null;
+      return cache.get(key) || undefined;
     },
     setItem(key, value) {
       cache.set(key, value);

--- a/src/drivers/memory.ts
+++ b/src/drivers/memory.ts
@@ -12,10 +12,10 @@ export default defineDriver<void>(() => {
       return data.has(key);
     },
     getItem(key) {
-      return data.get(key) || null;
+      return data.get(key) || undefined;
     },
     getItemRaw(key) {
-      return data.get(key) || null;
+      return data.get(key) || undefined;
     },
     setItem(key, value) {
       data.set(key, value);

--- a/src/drivers/memory.ts
+++ b/src/drivers/memory.ts
@@ -12,10 +12,10 @@ export default defineDriver<void>(() => {
       return data.has(key);
     },
     getItem(key) {
-      return data.get(key) || undefined;
+      return data.get(key) ?? undefined;
     },
     getItemRaw(key) {
-      return data.get(key) || undefined;
+      return data.get(key) ?? undefined;
     },
     setItem(key, value) {
       data.set(key, value);

--- a/src/drivers/mongodb.ts
+++ b/src/drivers/mongodb.ts
@@ -45,7 +45,7 @@ export default defineDriver((opts: MongoDbOptions) => {
     },
     async getItem(key) {
       const document = await getMongoCollection().findOne({ key });
-      return document?.value ? document.value : null;
+      return document?.value ? document.value : undefined;
     },
     async setItem(key, value) {
       const currentDateTime = new Date();

--- a/src/drivers/overlay.ts
+++ b/src/drivers/overlay.ts
@@ -31,13 +31,13 @@ export default defineDriver((options: OverlayStorageOptions) => {
       for (const layer of options.layers) {
         const value = await layer.getItem(key);
         if (value === OVERLAY_REMOVED) {
-          return null;
+          return undefined;
         }
-        if (value !== null) {
+        if (value !== undefined) {
           return value;
         }
       }
-      return null;
+      return undefined;
     },
     // TODO: Support native meta
     // async getMeta (key) {},

--- a/src/drivers/planetscale.ts
+++ b/src/drivers/planetscale.ts
@@ -62,7 +62,7 @@ export default defineDriver((opts: PlanetscaleDriverOptions = {}) => {
         `SELECT value from ${opts.table} WHERE id=:key;`,
         { key }
       );
-      return rows(res)[0]?.value ?? null;
+      return rows(res)[0]?.value ?? undefined;
     },
     setItem: async (key, value) => {
       await getConnection().execute(

--- a/src/drivers/redis.ts
+++ b/src/drivers/redis.ts
@@ -63,7 +63,7 @@ export default defineDriver((opts: RedisOptions = {}) => {
     },
     async getItem(key) {
       const value = await getRedisClient().get(p(key));
-      return value === undefined ? undefined : value;
+      return value ?? undefined;
     },
     async setItem(key, value, tOptions) {
       let ttl = tOptions?.ttl ?? opts.ttl;

--- a/src/drivers/redis.ts
+++ b/src/drivers/redis.ts
@@ -63,7 +63,7 @@ export default defineDriver((opts: RedisOptions = {}) => {
     },
     async getItem(key) {
       const value = await getRedisClient().get(p(key));
-      return value === null ? null : value;
+      return value === undefined ? undefined : value;
     },
     async setItem(key, value, tOptions) {
       let ttl = tOptions?.ttl ?? opts.ttl;

--- a/src/drivers/session-storage.ts
+++ b/src/drivers/session-storage.ts
@@ -36,7 +36,7 @@ export default defineDriver((opts: SessionStorageOptions = {}) => {
       return Object.prototype.hasOwnProperty.call(opts.sessionStorage, r(key));
     },
     getItem(key) {
-      return opts.sessionStorage!.getItem(r(key)) || undefined;
+      return opts.sessionStorage!.getItem(r(key)) ?? undefined;
     },
     setItem(key, value) {
       return opts.sessionStorage!.setItem(r(key), value);

--- a/src/drivers/session-storage.ts
+++ b/src/drivers/session-storage.ts
@@ -36,7 +36,7 @@ export default defineDriver((opts: SessionStorageOptions = {}) => {
       return Object.prototype.hasOwnProperty.call(opts.sessionStorage, r(key));
     },
     getItem(key) {
-      return opts.sessionStorage!.getItem(r(key));
+      return opts.sessionStorage!.getItem(r(key)) || undefined;
     },
     setItem(key, value) {
       return opts.sessionStorage!.setItem(r(key), value);

--- a/src/drivers/utils/node-fs.ts
+++ b/src/drivers/utils/node-fs.ts
@@ -2,11 +2,11 @@ import { Dirent, existsSync, promises as fsPromises } from "fs";
 import { resolve, dirname } from "path";
 
 function ignoreNotfound(err: any) {
-  return err.code === "ENOENT" || err.code === "EISDIR" ? null : err;
+  return err.code === "ENOENT" || err.code === "EISDIR" ? undefined : err;
 }
 
 function ignoreExists(err: any) {
-  return err.code === "EEXIST" ? null : err;
+  return err.code === "EEXIST" ? undefined : err;
 }
 
 type WriteFileData = Parameters<typeof fsPromises.writeFile>[1];

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,7 +41,7 @@ export interface Driver {
   getMeta?: (
     key: string,
     opts: TransactionOptions
-  ) => MaybePromise<StorageMeta | null>;
+  ) => MaybePromise<StorageMeta | undefined>;
   getKeys: (base: string, opts: TransactionOptions) => MaybePromise<string[]>;
   clear?: (base: string, opts: TransactionOptions) => MaybePromise<void>;
   dispose?: () => MaybePromise<void>;
@@ -54,12 +54,12 @@ export interface Storage<T extends StorageValue = StorageValue> {
   getItem: <U extends T>(
     key: string,
     opts?: TransactionOptions
-  ) => Promise<U | null>;
+  ) => Promise<U | undefined>;
   /** @experimental See https://github.com/unjs/unstorage/issues/142 */
   getItemRaw: <T = any>(
     key: string,
     opts?: TransactionOptions
-  ) => Promise<MaybeDefined<T> | null>;
+  ) => Promise<MaybeDefined<T> | undefined>;
   setItem: <U extends T>(
     key: string,
     value: U,

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,7 +23,7 @@ export interface Driver {
   getItem: (
     key: string,
     opts?: TransactionOptions
-  ) => MaybePromise<StorageValue>;
+  ) => MaybePromise<StorageValue | undefined>;
   /** @experimental */
   getItems?: (
     items: { key: string; options?: TransactionOptions }[],

--- a/test/drivers/cloudflare-kv-binding.test.ts
+++ b/test/drivers/cloudflare-kv-binding.test.ts
@@ -22,7 +22,7 @@ const mockBinding: KVNamespace = {
   },
   list(opts) {
     return mockStorage
-      .getKeys(opts?.prefix || undefined)
+      .getKeys(opts?.prefix ?? undefined)
       .then((keys) => ({ keys: keys.map((name) => ({ name })) })) as any;
   },
 };

--- a/test/drivers/cloudflare-kv-http.test.ts
+++ b/test/drivers/cloudflare-kv-http.test.ts
@@ -13,7 +13,7 @@ const server = setupServer(
   rest.get(`${baseURL}/values/:key`, (req, res, ctx) => {
     const key = req.params.key as string;
     if (!(key in store)) {
-      return res(ctx.status(404), ctx.json(null));
+      return res(ctx.status(404), ctx.json(undefined));
     }
     return res(
       ctx.status(200),
@@ -33,7 +33,7 @@ const server = setupServer(
   rest.put(`${baseURL}/values/:key`, async (req, res, ctx) => {
     const key = req.params.key as string;
     store[key] = await req.text();
-    return res(ctx.status(204), ctx.json(null));
+    return res(ctx.status(204), ctx.json(undefined));
   }),
 
   rest.delete(`${baseURL}/values/:key`, (req, res, ctx) => {

--- a/test/drivers/lru-cache.test.ts
+++ b/test/drivers/lru-cache.test.ts
@@ -19,10 +19,10 @@ describe("drivers: lru-cache with size", () => {
           "big",
           "0123456789012345678901234567890123456789012345678901234567890123456789"
         );
-        expect(await storage.getItem("big")).toBe(null);
+        expect(await storage.getItem("big")).toBe(undefined);
 
         await storage.setItemRaw("bigBuff", Buffer.alloc(100));
-        expect(await storage.getItemRaw("bigBuff")).toBe(null);
+        expect(await storage.getItemRaw("bigBuff")).toBe(undefined);
       });
     },
   });

--- a/test/drivers/utils.ts
+++ b/test/drivers/utils.ts
@@ -25,7 +25,7 @@ export function testDriver(opts: TestOptions) {
 
   it("initial state", async () => {
     expect(await ctx.storage.hasItem("s1:a")).toBe(false);
-    expect(await ctx.storage.getItem("s2:a")).toBe(null);
+    expect(await ctx.storage.getItem("s2:a")).toBe(undefined);
     expect(await ctx.storage.getKeys()).toMatchObject([]);
   });
 
@@ -108,7 +108,7 @@ export function testDriver(opts: TestOptions) {
   it("removeItem", async () => {
     await ctx.storage.removeItem("s1:a", false);
     expect(await ctx.storage.hasItem("s1:a")).toBe(false);
-    expect(await ctx.storage.getItem("s1:a")).toBe(null);
+    expect(await ctx.storage.getItem("s1:a")).toBe(undefined);
   });
 
   it("clear", async () => {

--- a/test/storage.test.ts
+++ b/test/storage.test.ts
@@ -119,7 +119,7 @@ describe("storage", () => {
 
     await storage.setItem("/mnt/foo/test.txt", "v3");
     storage.mount("/mnt/foo", memory());
-    expect(await storage.getItem("/mnt/foo/test.txt")).toBe(null);
+    expect(await storage.getItem("/mnt/foo/test.txt")).toBe(undefined);
 
     expect(await storage.getItem("/mnt/test.txt")).toBe("v2");
     expect(await storage.getKeys()).toMatchInlineSnapshot(`


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

Resolves #205

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This is a rework of #206

By changes to this PR, storage returns `undefined` instead of `null` when a key does not exist. 

On the downside, this change makes unstorage less consistent with local storage and Cloudflare KV when `getItem` returns `null` when the key does not exist.

On the benefits, more thinking this is less a breaking change for users but actually a fix since we were already listing `null` as a valid Storage value (which _does_ exist!). And we reduce use of evil null. (https://github.com/sindresorhus/meta/discussions/7)


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
