### PR TITLE
refactor: separate set item and get item options types

### DIFF
--- a/src/drivers/cloudflare-r2-binding.ts
+++ b/src/drivers/cloudflare-r2-binding.ts
@@ -53,12 +53,12 @@ export default defineDriver((opts: CloudflareR2Options) => {
     async setItem(key, value, topts) {
       key = r(key);
       const binding = getBinding(opts.binding);
-      await binding.put(key, value, topts);
+      await binding.put(key, value, topts as any);
     },
     async setItemRaw(key, value, topts) {
       key = r(key);
       const binding = getBinding(opts.binding);
-      await binding.put(key, value, topts);
+      await binding.put(key, value, topts as any);
     },
     async removeItem(key) {
       key = r(key);

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,36 +16,36 @@ export interface StorageMeta {
 
 export type TransactionOptions = Record<string, any>;
 
+export type GetItemOptions = TransactionOptions;
+export type SetItemOptions = { ttl?: number } & TransactionOptions;
+
 export interface Driver {
   name?: string;
   options?: any;
   hasItem: (key: string, opts: TransactionOptions) => MaybePromise<boolean>;
-  getItem: (
-    key: string,
-    opts?: TransactionOptions
-  ) => MaybePromise<StorageValue>;
+  getItem: (key: string, opts?: GetItemOptions) => MaybePromise<StorageValue>;
   /** @experimental */
   getItems?: (
-    items: { key: string; options?: TransactionOptions }[],
-    commonOptions?: TransactionOptions
+    items: { key: string; options?: GetItemOptions }[],
+    commonOptions?: GetItemOptions
   ) => MaybePromise<{ key: string; value: StorageValue }[]>;
   /** @experimental */
-  getItemRaw?: (key: string, opts: TransactionOptions) => MaybePromise<unknown>;
+  getItemRaw?: (key: string, opts: GetItemOptions) => MaybePromise<unknown>;
   setItem?: (
     key: string,
     value: string,
-    opts: TransactionOptions
+    opts: SetItemOptions
   ) => MaybePromise<void>;
   /** @experimental */
   setItems?: (
-    items: { key: string; value: string; options?: TransactionOptions }[],
-    commonOptions?: TransactionOptions
+    items: { key: string; value: string; options?: SetItemOptions }[],
+    commonOptions?: SetItemOptions
   ) => MaybePromise<void>;
   /** @experimental */
   setItemRaw?: (
     key: string,
     value: any,
-    opts: TransactionOptions
+    opts: SetItemOptions
   ) => MaybePromise<void>;
   removeItem?: (key: string, opts: TransactionOptions) => MaybePromise<void>;
   getMeta?: (


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

#262 

unblock #255
unblock #269 
 
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

@pi0 Instead of refactoring all the drivers, I think we can track expiration support in #262. 
This PR just adds support at the type level. 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
