### PR TITLE
fix(lru-cache, memory, mongodb, redis): return falsy values when set in storage

### DIFF
--- a/src/drivers/lru-cache.ts
+++ b/src/drivers/lru-cache.ts
@@ -29,10 +29,10 @@ export default defineDriver((opts: LRUDriverOptions = {}) => {
       return cache.has(key);
     },
     getItem(key) {
-      return cache.get(key) || null;
+      return cache.get(key) ?? null;
     },
     getItemRaw(key) {
-      return cache.get(key) || null;
+      return cache.get(key) ?? null;
     },
     setItem(key, value) {
       cache.set(key, value);

--- a/src/drivers/memory.ts
+++ b/src/drivers/memory.ts
@@ -12,10 +12,10 @@ export default defineDriver<void>(() => {
       return data.has(key);
     },
     getItem(key) {
-      return data.get(key) || null;
+      return data.get(key) ?? null;
     },
     getItemRaw(key) {
-      return data.get(key) || null;
+      return data.get(key) ?? null;
     },
     setItem(key, value) {
       data.set(key, value);

--- a/src/drivers/mongodb.ts
+++ b/src/drivers/mongodb.ts
@@ -45,7 +45,7 @@ export default defineDriver((opts: MongoDbOptions) => {
     },
     async getItem(key) {
       const document = await getMongoCollection().findOne({ key });
-      return document?.value ? document.value : null;
+      return document?.value ?? null;
     },
     async setItem(key, value) {
       const currentDateTime = new Date();

--- a/src/drivers/redis.ts
+++ b/src/drivers/redis.ts
@@ -63,7 +63,7 @@ export default defineDriver((opts: RedisOptions = {}) => {
     },
     async getItem(key) {
       const value = await getRedisClient().get(p(key));
-      return value === null ? null : value;
+      return value ?? null;
     },
     async setItem(key, value, tOptions) {
       let ttl = tOptions?.ttl ?? opts.ttl;

--- a/test/drivers/cloudflare-kv-binding.test.ts
+++ b/test/drivers/cloudflare-kv-binding.test.ts
@@ -43,6 +43,7 @@ describe("drivers: cloudflare-kv", () => {
               "json": "works",
             },
             "base:data:true.json": true,
+            "base:my-false-flag": false,
             "base:s1:a": "test_data",
             "base:s2:a": "test_data",
             "base:s3:a": "test_data",
@@ -52,6 +53,7 @@ describe("drivers: cloudflare-kv", () => {
             "base:v1:a": "test_data_v1:a",
             "base:v2:a": "test_data_v2:a",
             "base:v3:a": "test_data_v3:a?q=1",
+            "base:zero": 0,
           }
         `);
       });

--- a/test/drivers/cloudflare-kv-http.test.ts
+++ b/test/drivers/cloudflare-kv-http.test.ts
@@ -102,6 +102,7 @@ describe.skipIf(isNode18)("drivers: cloudflare-kv-http", () => {
             "base:data:serialized2.json": "{\\"serializedObj\\":\\"works\\"}",
             "base:data:test.json": "{\\"json\\":\\"works\\"}",
             "base:data:true.json": "true",
+            "base:my-false-flag": "false",
             "base:s1:a": "test_data",
             "base:s2:a": "test_data",
             "base:s3:a": "test_data",
@@ -111,6 +112,7 @@ describe.skipIf(isNode18)("drivers: cloudflare-kv-http", () => {
             "base:v1:a": "test_data_v1:a",
             "base:v2:a": "test_data_v2:a",
             "base:v3:a": "test_data_v3:a?q=1",
+            "base:zero": "0",
           }
         `);
       });

--- a/test/drivers/cloudflare-r2-binding.test.ts
+++ b/test/drivers/cloudflare-r2-binding.test.ts
@@ -59,6 +59,7 @@ describe("drivers: cloudflare-r2-binding", () => {
               "json": "works",
             },
             "base:data:true.json": true,
+            "base:my-false-flag": false,
             "base:s1:a": "test_data",
             "base:s2:a": "test_data",
             "base:s3:a": "test_data",
@@ -68,6 +69,7 @@ describe("drivers: cloudflare-r2-binding", () => {
             "base:v1:a": "test_data_v1:a",
             "base:v2:a": "test_data_v2:a",
             "base:v3:a": "test_data_v3:a?q=1",
+            "base:zero": 0,
           }
         `);
       });

--- a/test/drivers/redis.test.ts
+++ b/test/drivers/redis.test.ts
@@ -32,6 +32,8 @@ describe("drivers: redis", () => {
             "test:v1:a",
             "test:v2:a",
             "test:v3:a",
+            "test:zero",
+            "test:my-false-flag",
           ]
         `);
         await client.disconnect();

--- a/test/drivers/utils.ts
+++ b/test/drivers/utils.ts
@@ -135,6 +135,14 @@ export function testDriver(opts: TestOptions) {
     ]);
   });
 
+  it("getItem - return falsy values when set in storage", async () => {
+    await ctx.storage.setItem("zero", 0);
+    expect(await ctx.storage.getItem("zero")).toBe(0);
+
+    await ctx.storage.setItem("my-false-flag", false);
+    expect(await ctx.storage.getItem("my-false-flag")).toBe(false);
+  });
+
   // TODO: Refactor to move after cleanup
   if (opts.additionalTests) {
     opts.additionalTests(ctx);


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
- no related issue, just created fix when discovered it

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

I have noticed, that values resolved as Falsy were returned as `null`.
This PR is adding test for the driver to check if it returns values like `0` or `false` and not `null` and replaced some of the drivers that were returning incorrect results.

As the result `null` is returned only when:
1. there is no value in storage
2. value in storage is `null`
3. value in storage is `undefined`

cheers :)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
