### PR TITLE
feat(storage): allow record in watch callback

### DIFF
--- a/src/storage.ts
+++ b/src/storage.ts
@@ -69,13 +69,15 @@ export function createStorage<T extends StorageValue>(
       }));
   };
 
-  const onChange: WatchCallback = (event, key) => {
+  const onChange: WatchCallback = (event, resource) => {
     if (!context.watching) {
       return;
     }
-    key = normalizeKey(key);
+    resource = normalizeKey(
+      typeof resource === "string" ? resource : resource.key
+    );
     for (const listener of context.watchListeners) {
-      listener(event, key);
+      listener(event, resource);
     }
   };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,9 @@
 export type StorageValue = null | string | number | boolean | object;
 export type WatchEvent = "update" | "remove";
-export type WatchCallback = (event: WatchEvent, key: string) => any;
+export type WatchCallback = (
+  event: WatchEvent,
+  resource: string | Record<"key" | string, any>
+) => any;
 
 type MaybePromise<T> = T | Promise<T>;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,7 +2,7 @@ export type StorageValue = null | string | number | boolean | object;
 export type WatchEvent = "update" | "remove";
 export type WatchCallback = (
   event: WatchEvent,
-  resource: string | Record<"key" | string, any>
+  resource: string | (Record<string, any> & { key: string })
 ) => any;
 
 type MaybePromise<T> = T | Promise<T>;


### PR DESCRIPTION
### 🔗 Linked issue

#341 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

It provides flexibility in what the watch callback can return, when changes are detected.
Sometimes it can be highly useful to get both the `key` and the `value` of the property that was changed. I guess sometimes it can be used for some additional properties too.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
> I did not find in the docs any mentions of what callback must be defined as.
