### PR TITLE
fix(vercel-kv): add missing driver name

### DIFF
--- a/src/drivers/vercel-kv.ts
+++ b/src/drivers/vercel-kv.ts
@@ -21,6 +21,8 @@ export interface VercelKVOptions extends Partial<RedisConfigNodejs> {
   ttl?: number;
 }
 
+const DRIVER_NAME = "vercel-kv";
+
 export default defineDriver<VercelKVOptions>((opts) => {
   const base = normalizeKey(opts?.base);
   const r = (...keys: string[]) => joinKeys(base, ...keys);
@@ -60,6 +62,7 @@ export default defineDriver<VercelKVOptions>((opts) => {
   };
 
   return {
+    name: DRIVER_NAME,
     hasItem(key) {
       return getClient().exists(r(key)).then(Boolean);
     },


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

https://github.com/unjs/unstorage/issues/354

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Add the driver name to the Vercel KV driver

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
