### PR TITLE
docs: using undocs package manager component

### DIFF
--- a/docs/2.drivers/azure.md
+++ b/docs/2.drivers/azure.md
@@ -18,9 +18,7 @@ This driver uses the configuration store as a key value store. It uses the `key`
 
 To use it, you will need to install `@azure/app-configuration` and `@azure/identity` in your project:
 
-```bash
-npm i @azure/app-configuration @azure/identity
-```
+:pm-install{name="@azure/app-configuration @azure/identity"}
 
 Usage:
 
@@ -67,9 +65,7 @@ This driver stores KV information in a NoSQL API Cosmos DB collection as documen
 
 To use it, you will need to install `@azure/cosmos` and `@azure/identity` in your project:
 
-```bash
-npm i @azure/cosmos @azure/identity
-```
+:pm-install{name="@azure/cosmos @azure/identity"}
 
 Usage:
 
@@ -115,9 +111,7 @@ Please be aware that key vault secrets don't have the fastest access time and ar
 
 To use it, you will need to install `@azure/keyvault-secrets` and `@azure/identity` in your project:
 
-```bash
-npm i @azure/keyvault-secrets @azure/identity
-```
+:pm-install{name="@azure/keyvault-secrets @azure/identity"}
 
 Usage:
 
@@ -160,9 +154,7 @@ This driver stores KV information in a Azure blob storage blob. The same contain
 
 To use it, you will need to install `@azure/storage-blob` and `@azure/identity` in your project:
 
-```bash
-npm i @azure/storage-blob @azure/identity
-```
+:pm-install{name="@azure/storage-blob @azure/identity"}
 
 Please make sure that the container you want to use exists in your storage account.
 
@@ -215,9 +207,7 @@ This driver stores KV information in a Azure table storage. The same partition k
 
 To use it, you will need to install `@azure/data-table` and `@azure/identity` in your project:
 
-```bash
-npm i @azure/data-table @azure/identity
-```
+:pm-install{name="@azure/data-table @azure/identity"}
 
 Please make sure that the table you want to use exists in your storage account.
 

--- a/docs/2.drivers/browser.md
+++ b/docs/2.drivers/browser.md
@@ -66,9 +66,7 @@ Learn more about IndexedDB.
 
 To use it, you will need to install [`idb-keyval`](https://github.com/jakearchibald/idb-keyval) in your project:
 
-```bash [Terminal]
-npm i idb-keyval
-```
+:pm-install{name="idb-keyval"}
 
 Usage:
 

--- a/docs/2.drivers/capacitor-preferences.md
+++ b/docs/2.drivers/capacitor-preferences.md
@@ -14,24 +14,8 @@ Learn more about Capacitor Preferences API.
 
 To use this driver, you need to install and sync `@capacitor/preferences` inside your capacitor project:
 
-::code-group
-
-```sh [npm]
-npm install @capacitor/preferences
-npx cap sync
-```
-
-```sh [Yarn]
-yarn add @capacitor/preferences
-npx cap sync
-```
-
-```sh [pnpm]
-pnpm add @capacitor/preferences
-pnpm cap sync
-```
-
-::
+:pm-install{name="@capacitor/preferences"}
+:pm-x{command="cap sync"}
 
 Usage:
 

--- a/docs/2.drivers/mongodb.md
+++ b/docs/2.drivers/mongodb.md
@@ -16,9 +16,7 @@ This driver stores KV information in a MongoDB collection with a separate docume
 
 To use it, you will need to install `mongodb` in your project:
 
-```bash [Terminal]
-npm i mongodb
-```
+:pm-install{name="mongodb"}
 
 Usage:
 

--- a/docs/2.drivers/redis.md
+++ b/docs/2.drivers/redis.md
@@ -18,9 +18,7 @@ Unstorage uses [`ioredis`](https://github.com/luin/ioredis) internally to connec
 
 To use it, you will need to install `ioredis` in your project:
 
-```bash [Terminal]
-npm i ioredis
-```
+:pm-install{name="ioredis"}
 
 Usage with single Redis instance:
 


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

I noticed documentations for drivers were showing only the `npm i` command.
I changed them to use the package manager component from undocs. 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
