### PR TITLE
feat: FSStorageOptions in fs-lite and fs drivers custom baseResolve

### DIFF
--- a/src/drivers/fs-lite.ts
+++ b/src/drivers/fs-lite.ts
@@ -25,73 +25,69 @@ const PATH_TRAVERSE_RE = /\.\.\:|\.\.$/;
 
 const DRIVER_NAME = "fs-lite";
 
-export default defineDriver(
-  (
-    opts: FSStorageOptions = {
-      baseResolve: true,
-    }
-  ) => {
-    if (!opts.base) {
-      throw createRequiredError(DRIVER_NAME, "base");
-    }
-
-    opts.base = opts.baseResolve ? resolve(opts.base) : opts.base;
-    const r = (key: string) => {
-      if (PATH_TRAVERSE_RE.test(key)) {
-        throw createError(
-          DRIVER_NAME,
-          `Invalid key: ${JSON.stringify(key)}. It should not contain .. segments`
-        );
-      }
-      const resolved = join(opts.base!, key.replace(/:/g, "/"));
-      return resolved;
-    };
-
-    return {
-      name: DRIVER_NAME,
-      options: opts,
-      hasItem(key) {
-        return existsSync(r(key));
-      },
-      getItem(key) {
-        return readFile(r(key), "utf8");
-      },
-      getItemRaw(key) {
-        return readFile(r(key));
-      },
-      async getMeta(key) {
-        const { atime, mtime, size, birthtime, ctime } = await fsp
-          .stat(r(key))
-          .catch(() => ({}) as Stats);
-        return { atime, mtime, size, birthtime, ctime };
-      },
-      setItem(key, value) {
-        if (opts.readOnly) {
-          return;
-        }
-        return writeFile(r(key), value, "utf8");
-      },
-      setItemRaw(key, value) {
-        if (opts.readOnly) {
-          return;
-        }
-        return writeFile(r(key), value);
-      },
-      removeItem(key) {
-        if (opts.readOnly) {
-          return;
-        }
-        return unlink(r(key));
-      },
-      getKeys() {
-        return readdirRecursive(r("."), opts.ignore);
-      },
-      async clear() {
-        if (opts.readOnly || opts.noClear) {
-          return;
-        }
-        await rmRecursive(r("."));
-      },
-    };
+export default defineDriver((opts: FSStorageOptions = {
+  baseResolve: true
+}) => {
+  if (!opts.base) {
+    throw createRequiredError(DRIVER_NAME, "base");
   }
-);
+
+  opts.base = opts.baseResolve ? resolve(opts.base) : opts.base;
+  const r = (key: string) => {
+    if (PATH_TRAVERSE_RE.test(key)) {
+      throw createError(
+        DRIVER_NAME,
+        `Invalid key: ${JSON.stringify(key)}. It should not contain .. segments`
+      );
+    }
+    const resolved = join(opts.base!, key.replace(/:/g, "/"));
+    return resolved;
+  };
+
+  return {
+    name: DRIVER_NAME,
+    options: opts,
+    hasItem(key) {
+      return existsSync(r(key));
+    },
+    getItem(key) {
+      return readFile(r(key), "utf8");
+    },
+    getItemRaw(key) {
+      return readFile(r(key));
+    },
+    async getMeta(key) {
+      const { atime, mtime, size, birthtime, ctime } = await fsp
+        .stat(r(key))
+        .catch(() => ({}) as Stats);
+      return { atime, mtime, size, birthtime, ctime };
+    },
+    setItem(key, value) {
+      if (opts.readOnly) {
+        return;
+      }
+      return writeFile(r(key), value, "utf8");
+    },
+    setItemRaw(key, value) {
+      if (opts.readOnly) {
+        return;
+      }
+      return writeFile(r(key), value);
+    },
+    removeItem(key) {
+      if (opts.readOnly) {
+        return;
+      }
+      return unlink(r(key));
+    },
+    getKeys() {
+      return readdirRecursive(r("."), opts.ignore);
+    },
+    async clear() {
+      if (opts.readOnly || opts.noClear) {
+        return;
+      }
+      await rmRecursive(r("."));
+    },
+  };
+});

--- a/src/drivers/fs.ts
+++ b/src/drivers/fs.ts
@@ -13,6 +13,10 @@ import anymatch from "anymatch";
 
 export interface FSStorageOptions {
   base?: string;
+  /**
+   * @default true
+   */
+  baseResolve?: boolean;
   ignore?: string[];
   readOnly?: boolean;
   noClear?: boolean;
@@ -23,109 +27,115 @@ const PATH_TRAVERSE_RE = /\.\.\:|\.\.$/;
 
 const DRIVER_NAME = "fs";
 
-export default defineDriver((opts: FSStorageOptions = {}) => {
-  if (!opts.base) {
-    throw createRequiredError(DRIVER_NAME, "base");
-  }
-
-  if (!opts.ignore) {
-    opts.ignore = ["**/node_modules/**", "**/.git/**"];
-  }
-
-  opts.base = resolve(opts.base);
-  const r = (key: string) => {
-    if (PATH_TRAVERSE_RE.test(key)) {
-      throw createError(
-        DRIVER_NAME,
-        `Invalid key: ${JSON.stringify(key)}. It should not contain .. segments`
-      );
+export default defineDriver(
+  (
+    opts: FSStorageOptions = {
+      baseResolve: true,
     }
-    const resolved = join(opts.base!, key.replace(/:/g, "/"));
-    return resolved;
-  };
-
-  let _watcher: FSWatcher | undefined;
-  const _unwatch = async () => {
-    if (_watcher) {
-      await _watcher.close();
-      _watcher = undefined;
+  ) => {
+    if (!opts.base) {
+      throw createRequiredError(DRIVER_NAME, "base");
     }
-  };
 
-  return {
-    name: DRIVER_NAME,
-    options: opts,
-    hasItem(key) {
-      return existsSync(r(key));
-    },
-    getItem(key) {
-      return readFile(r(key), "utf8");
-    },
-    getItemRaw(key) {
-      return readFile(r(key));
-    },
-    async getMeta(key) {
-      const { atime, mtime, size, birthtime, ctime } = await fsp
-        .stat(r(key))
-        .catch(() => ({}) as Stats);
-      return { atime, mtime, size, birthtime, ctime };
-    },
-    setItem(key, value) {
-      if (opts.readOnly) {
-        return;
+    if (!opts.ignore) {
+      opts.ignore = ["**/node_modules/**", "**/.git/**"];
+    }
+
+    opts.base = opts.baseResolve ? resolve(opts.base) : opts.base;
+    const r = (key: string) => {
+      if (PATH_TRAVERSE_RE.test(key)) {
+        throw createError(
+          DRIVER_NAME,
+          `Invalid key: ${JSON.stringify(key)}. It should not contain .. segments`
+        );
       }
-      return writeFile(r(key), value, "utf8");
-    },
-    setItemRaw(key, value) {
-      if (opts.readOnly) {
-        return;
-      }
-      return writeFile(r(key), value);
-    },
-    removeItem(key) {
-      if (opts.readOnly) {
-        return;
-      }
-      return unlink(r(key));
-    },
-    getKeys() {
-      return readdirRecursive(r("."), anymatch(opts.ignore || []));
-    },
-    async clear() {
-      if (opts.readOnly || opts.noClear) {
-        return;
-      }
-      await rmRecursive(r("."));
-    },
-    async dispose() {
+      const resolved = join(opts.base!, key.replace(/:/g, "/"));
+      return resolved;
+    };
+
+    let _watcher: FSWatcher | undefined;
+    const _unwatch = async () => {
       if (_watcher) {
         await _watcher.close();
+        _watcher = undefined;
       }
-    },
-    async watch(callback) {
-      if (_watcher) {
-        return _unwatch;
-      }
-      await new Promise<void>((resolve, reject) => {
-        _watcher = watch(opts.base!, {
-          ignoreInitial: true,
-          ignored: opts.ignore,
-          ...opts.watchOptions,
-        })
-          .on("ready", () => {
-            resolve();
+    };
+
+    return {
+      name: DRIVER_NAME,
+      options: opts,
+      hasItem(key) {
+        return existsSync(r(key));
+      },
+      getItem(key) {
+        return readFile(r(key), "utf8");
+      },
+      getItemRaw(key) {
+        return readFile(r(key));
+      },
+      async getMeta(key) {
+        const { atime, mtime, size, birthtime, ctime } = await fsp
+          .stat(r(key))
+          .catch(() => ({}) as Stats);
+        return { atime, mtime, size, birthtime, ctime };
+      },
+      setItem(key, value) {
+        if (opts.readOnly) {
+          return;
+        }
+        return writeFile(r(key), value, "utf8");
+      },
+      setItemRaw(key, value) {
+        if (opts.readOnly) {
+          return;
+        }
+        return writeFile(r(key), value);
+      },
+      removeItem(key) {
+        if (opts.readOnly) {
+          return;
+        }
+        return unlink(r(key));
+      },
+      getKeys() {
+        return readdirRecursive(r("."), anymatch(opts.ignore || []));
+      },
+      async clear() {
+        if (opts.readOnly || opts.noClear) {
+          return;
+        }
+        await rmRecursive(r("."));
+      },
+      async dispose() {
+        if (_watcher) {
+          await _watcher.close();
+        }
+      },
+      async watch(callback) {
+        if (_watcher) {
+          return _unwatch;
+        }
+        await new Promise<void>((resolve, reject) => {
+          _watcher = watch(opts.base!, {
+            ignoreInitial: true,
+            ignored: opts.ignore,
+            ...opts.watchOptions,
           })
-          .on("error", reject)
-          .on("all", (eventName, path) => {
-            path = relative(opts.base!, path);
-            if (eventName === "change" || eventName === "add") {
-              callback("update", path);
-            } else if (eventName === "unlink") {
-              callback("remove", path);
-            }
-          });
-      });
-      return _unwatch;
-    },
-  };
-});
+            .on("ready", () => {
+              resolve();
+            })
+            .on("error", reject)
+            .on("all", (eventName, path) => {
+              path = relative(opts.base!, path);
+              if (eventName === "change" || eventName === "add") {
+                callback("update", path);
+              } else if (eventName === "unlink") {
+                callback("remove", path);
+              }
+            });
+        });
+        return _unwatch;
+      },
+    };
+  }
+);

--- a/src/drivers/fs.ts
+++ b/src/drivers/fs.ts
@@ -27,115 +27,111 @@ const PATH_TRAVERSE_RE = /\.\.\:|\.\.$/;
 
 const DRIVER_NAME = "fs";
 
-export default defineDriver(
-  (
-    opts: FSStorageOptions = {
-      baseResolve: true,
-    }
-  ) => {
-    if (!opts.base) {
-      throw createRequiredError(DRIVER_NAME, "base");
-    }
+export default defineDriver((opts: FSStorageOptions = {
+  baseResolve: true
+}) => {
+  if (!opts.base) {
+    throw createRequiredError(DRIVER_NAME, "base");
+  }
 
-    if (!opts.ignore) {
-      opts.ignore = ["**/node_modules/**", "**/.git/**"];
-    }
+  if (!opts.ignore) {
+    opts.ignore = ["**/node_modules/**", "**/.git/**"];
+  }
 
-    opts.base = opts.baseResolve ? resolve(opts.base) : opts.base;
-    const r = (key: string) => {
-      if (PATH_TRAVERSE_RE.test(key)) {
-        throw createError(
-          DRIVER_NAME,
-          `Invalid key: ${JSON.stringify(key)}. It should not contain .. segments`
-        );
+  opts.base = opts.baseResolve ? resolve(opts.base) : opts.base;
+  const r = (key: string) => {
+    if (PATH_TRAVERSE_RE.test(key)) {
+      throw createError(
+        DRIVER_NAME,
+        `Invalid key: ${JSON.stringify(key)}. It should not contain .. segments`
+      );
+    }
+    const resolved = join(opts.base!, key.replace(/:/g, "/"));
+    return resolved;
+  };
+
+  let _watcher: FSWatcher | undefined;
+  const _unwatch = async () => {
+    if (_watcher) {
+      await _watcher.close();
+      _watcher = undefined;
+    }
+  };
+
+  return {
+    name: DRIVER_NAME,
+    options: opts,
+    hasItem(key) {
+      return existsSync(r(key));
+    },
+    getItem(key) {
+      return readFile(r(key), "utf8");
+    },
+    getItemRaw(key) {
+      return readFile(r(key));
+    },
+    async getMeta(key) {
+      const { atime, mtime, size, birthtime, ctime } = await fsp
+        .stat(r(key))
+        .catch(() => ({}) as Stats);
+      return { atime, mtime, size, birthtime, ctime };
+    },
+    setItem(key, value) {
+      if (opts.readOnly) {
+        return;
       }
-      const resolved = join(opts.base!, key.replace(/:/g, "/"));
-      return resolved;
-    };
-
-    let _watcher: FSWatcher | undefined;
-    const _unwatch = async () => {
+      return writeFile(r(key), value, "utf8");
+    },
+    setItemRaw(key, value) {
+      if (opts.readOnly) {
+        return;
+      }
+      return writeFile(r(key), value);
+    },
+    removeItem(key) {
+      if (opts.readOnly) {
+        return;
+      }
+      return unlink(r(key));
+    },
+    getKeys() {
+      return readdirRecursive(r("."), anymatch(opts.ignore || []));
+    },
+    async clear() {
+      if (opts.readOnly || opts.noClear) {
+        return;
+      }
+      await rmRecursive(r("."));
+    },
+    async dispose() {
       if (_watcher) {
         await _watcher.close();
-        _watcher = undefined;
       }
-    };
-
-    return {
-      name: DRIVER_NAME,
-      options: opts,
-      hasItem(key) {
-        return existsSync(r(key));
-      },
-      getItem(key) {
-        return readFile(r(key), "utf8");
-      },
-      getItemRaw(key) {
-        return readFile(r(key));
-      },
-      async getMeta(key) {
-        const { atime, mtime, size, birthtime, ctime } = await fsp
-          .stat(r(key))
-          .catch(() => ({}) as Stats);
-        return { atime, mtime, size, birthtime, ctime };
-      },
-      setItem(key, value) {
-        if (opts.readOnly) {
-          return;
-        }
-        return writeFile(r(key), value, "utf8");
-      },
-      setItemRaw(key, value) {
-        if (opts.readOnly) {
-          return;
-        }
-        return writeFile(r(key), value);
-      },
-      removeItem(key) {
-        if (opts.readOnly) {
-          return;
-        }
-        return unlink(r(key));
-      },
-      getKeys() {
-        return readdirRecursive(r("."), anymatch(opts.ignore || []));
-      },
-      async clear() {
-        if (opts.readOnly || opts.noClear) {
-          return;
-        }
-        await rmRecursive(r("."));
-      },
-      async dispose() {
-        if (_watcher) {
-          await _watcher.close();
-        }
-      },
-      async watch(callback) {
-        if (_watcher) {
-          return _unwatch;
-        }
-        await new Promise<void>((resolve, reject) => {
-          _watcher = watch(opts.base!, {
-            ignoreInitial: true,
-            ignored: opts.ignore,
-            ...opts.watchOptions,
-          })
-            .on("ready", () => {
-              resolve();
-            })
-            .on("error", reject)
-            .on("all", (eventName, path) => {
-              path = relative(opts.base!, path);
-              if (eventName === "change" || eventName === "add") {
-                callback("update", path);
-              } else if (eventName === "unlink") {
-                callback("remove", path);
-              }
-            });
-        });
+    },
+    async watch(callback) {
+      if (_watcher) {
         return _unwatch;
-      },
-    };
-  }
-);
+      }
+      await new Promise<void>((resolve, reject) => {
+        _watcher = watch(opts.base!, {
+          ignoreInitial: true,
+          ignored: opts.ignore,
+          ...opts.watchOptions,
+        })
+          .on("ready", () => {
+            resolve();
+          })
+          .on("error", reject)
+          .on("all", (eventName, path) => {
+            path = relative(opts.base!, path);
+            if (eventName === "change" || eventName === "add") {
+              callback("update", path);
+            } else if (eventName === "unlink") {
+              callback("remove", path);
+            }
+          });
+      });
+      return _unwatch;
+    },
+  };
+});


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

After builds the device chooses its path but I wanted to give it somewhere else.

```
storage.mount('graphql', unstorage_47drivers_47fs({"driver":"fs","base":"/Users/productdevbook/project/template-simple/data/graphql","ignore":["**/node_modules/**","**/.git/**"]})); 
```

In some cases I wanted to give docker a custom path. I thought of this as a solution to this problem.

```
  nitro: {
    storage: {
      graphql: {
        driver: 'fs',
        base: process.env.NODE_ENV === 'production' ? '/app/data/graphql' : 'data/graphql',
        resolveBase: process.env.NODE_ENV !== 'production',
      },
    },
  },
```

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
