### PR TITLE
fix: make setItems and getItems work with prefixStorage

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,8 +5,10 @@ type StorageKeys = Array<keyof Storage>;
 const storageKeyProperties: StorageKeys = [
   "hasItem",
   "getItem",
+  "getItems",
   "getItemRaw",
   "setItem",
+  "setItems",
   "setItemRaw",
   "removeItem",
   "getMeta",
@@ -27,11 +29,22 @@ export function prefixStorage<T extends StorageValue>(
     return storage;
   }
   const nsStorage: Storage = { ...storage };
+  const keysPropertyRegexp = new RegExp(/(set|get)\w+s/);
   for (const property of storageKeyProperties) {
-    // @ts-ignore
-    nsStorage[property] = (key = "", ...args) =>
+    if (keysPropertyRegexp.test(property)) {
       // @ts-ignore
-      storage[property](base + key, ...args);
+      nsStorage[property] = (keys = [], ...args) =>
+        // @ts-ignore
+        storage[property](
+          keys.map((key) => base + key),
+          ...args
+        );
+    } else {
+      // @ts-ignore
+      nsStorage[property] = (key = "", ...args) =>
+        // @ts-ignore
+        storage[property](base + key, ...args);
+    }
   }
   nsStorage.getKeys = (key = "", ...arguments_) =>
     storage


### PR DESCRIPTION
🔗 Linked issue

fix https://github.com/unjs/unstorage/issues/396

❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

📚 Description

When using setItems and getItems, prefixStorage can't handle base and key splice properly. storageKeyProperties doesn't contain setItems and getItems, and the original processing doesn't support passing parameters as arrays.

I added a regular expression to determine what type the current storageKey should be, and when it meets the condition, it will use traversal to splice the base and key together. The regular expression is now set to /(set|get)\w+s/, which I think should be backward compatible with APIs that conform to the naming convention, and since this processing is performed during traversal, it can be overridden later if the developer isn't happy with the established processing.

📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
