### PR TITLE
fix(cf-kv): go through all pages to list the keys

### DIFF
--- a/src/drivers/cloudflare-kv-binding.ts
+++ b/src/drivers/cloudflare-kv-binding.ts
@@ -18,8 +18,18 @@ export default defineDriver((opts: KVOptions) => {
   async function getKeys(base: string = "") {
     base = r(base);
     const binding = getKVBinding(opts.binding);
-    const kvList = await binding.list(base ? { prefix: base } : undefined);
-    return kvList.keys.map((key) => key.name);
+    const keys = [];
+    let cursor: string | undefined = undefined;
+    do {
+      const kvList = await binding.list({ prefix: base || undefined, cursor });
+
+      keys.push(...kvList.keys.map((key) => key.name));
+      cursor = (kvList.list_complete ? undefined : kvList.cursor) as
+        | string
+        | undefined;
+    } while (cursor);
+
+    return keys;
   }
 
   return {


### PR DESCRIPTION
Based on the official documentation, KV list function has maximum limit of 1000 keys. I n order to get all keys from the KV binding, we need to go through all pages using the `cursor` property.

This PR updates `getKeys` function to leverage `cursor`.

<img width="851" alt="Screenshot 2024-07-05 at 14 15 37" src="https://github.com/unjs/unstorage/assets/2047945/e5937304-4d09-4bfc-8708-3d51da806b2d">

Originally raised in nuxt-hub/platform#254