### PR TITLE
perf(cloudflare-kv-binding): add missing base argument on `getKeys`

### DIFF
--- a/src/drivers/cloudflare-kv-binding.ts
+++ b/src/drivers/cloudflare-kv-binding.ts
@@ -65,8 +65,8 @@ export default defineDriver((opts: KVOptions) => {
       const binding = getKVBinding(opts.binding);
       return binding.delete(key);
     },
-    getKeys() {
-      return getKeys().then((keys) =>
+    getKeys(base) {
+      return getKeys(base).then((keys) =>
         keys.map((key) => (opts.base ? key.slice(opts.base.length) : key))
       );
     },


### PR DESCRIPTION
This will give the prefix and avoid looping through all the main namespace, this is an important fix in term of performance when dealing with a lot of keys.