### PR TITLE
feat(http, server): support native `ttl`

### DIFF
--- a/docs/2.drivers/http.md
+++ b/docs/2.drivers/http.md
@@ -32,10 +32,12 @@ const storage = createStorage({
 
 - `getItem`: Maps to http `GET`. Returns deserialized value if response is ok
 - `hasItem`: Maps to http `HEAD`. Returns `true` if response is ok (200)
-- `setItem`: Maps to http `PUT`. Sends serialized value using body
+- `getMeta`: Maps to http `HEAD` (headers: `last-modified` => `mtime`, `x-ttl` => `ttl`)
+- `setItem`: Maps to http `PUT`. Sends serialized value using body (`ttl` option will be sent as `x-ttl` header).
 - `removeItem`: Maps to `DELETE`
 - `clear`: Not supported
 
 **Transaction Options:**
 
 - `headers`: Custom headers to be sent on each operation (`getItem`, `setItem`, etc)
+- `ttl`: Custom `ttl` (in seconds) for supported drivers. Will be mapped to `x-ttl` http header.

--- a/src/drivers/http.ts
+++ b/src/drivers/http.ts
@@ -1,3 +1,4 @@
+import type { TransactionOptions } from "../types";
 import { defineDriver } from "./utils";
 import { type FetchError, $fetch as _fetch } from "ofetch";
 import { joinURL } from "ufo";
@@ -22,82 +23,97 @@ export default defineDriver((opts: HTTPOptions) => {
     throw error;
   };
 
+  const getHeaders = (
+    topts: TransactionOptions | undefined,
+    defaultHeaders?: Record<string, string>
+  ) => {
+    const headers = {
+      ...defaultHeaders,
+      ...opts.headers,
+      ...topts?.headers,
+    };
+    if (topts?.ttl && !headers["x-ttl"]) {
+      headers["x-ttl"] = topts.ttl + "";
+    }
+    return headers;
+  };
+
   return {
     name: DRIVER_NAME,
     options: opts,
     hasItem(key, topts) {
       return _fetch(r(key), {
         method: "HEAD",
-        headers: { ...opts.headers, ...topts.headers },
+        headers: getHeaders(topts),
       })
         .then(() => true)
         .catch((err) => catchFetchError(err, false));
     },
-    async getItem(key, tops = {}) {
+    async getItem(key, tops) {
       const value = await _fetch(r(key), {
-        headers: { ...opts.headers, ...tops.headers },
+        headers: getHeaders(tops),
       }).catch(catchFetchError);
       return value;
     },
     async getItemRaw(key, topts) {
       const value = await _fetch(r(key), {
-        headers: {
-          accept: "application/octet-stream",
-          ...opts.headers,
-          ...topts.headers,
-        },
+        headers: getHeaders(topts, { accept: "application/octet-stream" }),
       }).catch(catchFetchError);
       return value;
     },
     async getMeta(key, topts) {
       const res = await _fetch.raw(r(key), {
         method: "HEAD",
-        headers: { ...opts.headers, ...topts.headers },
+        headers: getHeaders(topts),
       });
       let mtime = undefined;
+      let ttl = undefined;
       const _lastModified = res.headers.get("last-modified");
       if (_lastModified) {
         mtime = new Date(_lastModified);
       }
+      const _ttl = res.headers.get("x-ttl");
+      if (_ttl) {
+        ttl = Number.parseInt(_ttl, 10);
+      }
       return {
         status: res.status,
         mtime,
+        ttl,
       };
     },
     async setItem(key, value, topts) {
       await _fetch(r(key), {
         method: "PUT",
         body: value,
-        headers: { ...opts.headers, ...topts?.headers },
+        headers: getHeaders(topts),
       });
     },
     async setItemRaw(key, value, topts) {
       await _fetch(r(key), {
         method: "PUT",
         body: value,
-        headers: {
+        headers: getHeaders(topts, {
           "content-type": "application/octet-stream",
-          ...opts.headers,
-          ...topts.headers,
-        },
+        }),
       });
     },
     async removeItem(key, topts) {
       await _fetch(r(key), {
         method: "DELETE",
-        headers: { ...opts.headers, ...topts.headers },
+        headers: getHeaders(topts),
       });
     },
     async getKeys(base, topts) {
       const value = await _fetch(rBase(base), {
-        headers: { ...opts.headers, ...topts.headers },
+        headers: getHeaders(topts),
       });
       return Array.isArray(value) ? value : [];
     },
     async clear(base, topts) {
       await _fetch(rBase(base), {
         method: "DELETE",
-        headers: { ...opts.headers, ...topts.headers },
+        headers: getHeaders(topts),
       });
     },
   };

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,10 +11,20 @@ export type Unwatch = () => MaybePromise<void>;
 export interface StorageMeta {
   atime?: Date;
   mtime?: Date;
+  ttl?: number;
   [key: string]: StorageValue | Date | undefined;
 }
 
-export type TransactionOptions = Record<string, any>;
+export interface TransactionOptions {
+  [key: string]: any;
+
+  /**
+   * Time to live in seconds
+   *
+   * **Note:** Native TTL support is not supported by all drivers
+   */
+  ttl?: number;
+}
 
 export interface Driver<OptionsT = any, InstanceT = any> {
   name?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,16 +15,8 @@ export interface StorageMeta {
   [key: string]: StorageValue | Date | undefined;
 }
 
-export interface TransactionOptions {
-  [key: string]: any;
-
-  /**
-   * Time to live in seconds
-   *
-   * **Note:** Native TTL support is not supported by all drivers
-   */
-  ttl?: number;
-}
+// TODO: type ttl
+export type TransactionOptions = Record<string, any>;
 
 export interface Driver<OptionsT = any, InstanceT = any> {
   name?: string;


### PR DESCRIPTION
Some drivers (cloudflare, vercel, and Redis) support the native `ttl` transaction option.

With HTTP/server pair to do remote operations, these parameters weren't passing.

This PR supports it by using the custom `x-ttl` HTTP header in requests for `setItem` and `x-ttl` + `Cache-Control: max-age=<ttl>` response headers for server HEAD/GET responses.

**Note:** This feature is not to pass arbitrary transaction options (as they can contain sensitive information or large payload) and also not arbitrary support of `ttl` as (stored) meta but only for the drivers that support it natively. in later versions we support arbitrary value+meta as FormData body.