### PR TITLE
fix(cloudflare-kv): use min ttl of 60 seconds

### DIFF
--- a/src/drivers/cloudflare-kv-binding.ts
+++ b/src/drivers/cloudflare-kv-binding.ts
@@ -8,7 +8,7 @@ export interface KVOptions {
   base?: string;
 
   /**
-   * The minimum time-to-live (TTL) for a key-value pair in seconds.
+   * The minimum time-to-live (ttl) for setItem in seconds.
    * The default is 60 seconds as per Cloudflare's documentation.
    */
   minTTL?: number;

--- a/src/drivers/cloudflare-kv-binding.ts
+++ b/src/drivers/cloudflare-kv-binding.ts
@@ -9,7 +9,7 @@ export interface KVOptions {
 
   /**
    * The minimum time-to-live (ttl) for setItem in seconds.
-   * The default is 60 seconds as per Cloudflare's documentation.
+   * The default is 60 seconds as per Cloudflare's [documentation](https://developers.cloudflare.com/kv/api/write-key-value-pairs/).
    */
   minTTL?: number;
 }

--- a/src/drivers/cloudflare-kv-binding.ts
+++ b/src/drivers/cloudflare-kv-binding.ts
@@ -60,7 +60,9 @@ export default defineDriver((opts: KVOptions) => {
         value,
         topts
           ? {
-              expirationTtl: Math.max(topts.ttl, opts.minTTL ?? 60),
+              expirationTtl: topts?.ttl
+                ? Math.max(topts.ttl, opts.minTTL ?? 60)
+                : undefined,
               ...topts,
             }
           : undefined

--- a/src/drivers/cloudflare-kv-binding.ts
+++ b/src/drivers/cloudflare-kv-binding.ts
@@ -6,6 +6,12 @@ export interface KVOptions {
 
   /** Adds prefix to all stored keys */
   base?: string;
+
+  /**
+   * The minimum time-to-live (TTL) for a key-value pair in seconds.
+   * The default is 60 seconds as per Cloudflare's documentation.
+   */
+  minTTL?: number;
 }
 
 // https://developers.cloudflare.com/workers/runtime-apis/kv
@@ -54,7 +60,7 @@ export default defineDriver((opts: KVOptions) => {
         value,
         topts
           ? {
-              expirationTtl: topts.ttl,
+              expirationTtl: Math.max(topts.ttl, opts.minTTL ?? 60),
               ...topts,
             }
           : undefined

--- a/src/drivers/cloudflare-kv-http.ts
+++ b/src/drivers/cloudflare-kv-http.ts
@@ -57,6 +57,11 @@ export type KVHTTPOptions = {
    * Adds prefix to all stored keys
    */
   base?: string;
+  /**
+   * The minimum time-to-live (ttl) for setItem in seconds.
+   * The default is 60 seconds as per Cloudflare's documentation.
+   */
+  minTTL?: number;
 } & (KVAuthServiceKey | KVAuthAPIToken | KVAuthEmailKey);
 
 type CloudflareAuthorizationHeaders =
@@ -140,11 +145,13 @@ export default defineDriver<KVHTTPOptions>((opts) => {
     }
   };
 
-  const setItem = async (key: string, value: any, opt: any) => {
+  const setItem = async (key: string, value: any, topts: any) => {
     return await kvFetch(`/values/${r(key)}`, {
       method: "PUT",
       body: value,
-      query: opt?.ttl ? { expiration_ttl: opt?.ttl } : {},
+      query: topts?.ttl
+        ? { expiration_ttl: Math.max(topts?.ttl, opts.minTTL || 60) }
+        : {},
     });
   };
 

--- a/src/drivers/cloudflare-kv-http.ts
+++ b/src/drivers/cloudflare-kv-http.ts
@@ -151,7 +151,7 @@ export default defineDriver<KVHTTPOptions>((opts) => {
       body: value,
       query: topts?.ttl
         ? { expiration_ttl: Math.max(topts?.ttl, opts.minTTL || 60) }
-        : {},
+        : undefined,
     });
   };
 

--- a/src/drivers/cloudflare-kv-http.ts
+++ b/src/drivers/cloudflare-kv-http.ts
@@ -59,7 +59,7 @@ export type KVHTTPOptions = {
   base?: string;
   /**
    * The minimum time-to-live (ttl) for setItem in seconds.
-   * The default is 60 seconds as per Cloudflare's documentation.
+   * The default is 60 seconds as per Cloudflare's [documentation](https://developers.cloudflare.com/kv/api/write-key-value-pairs/).
    */
   minTTL?: number;
 } & (KVAuthServiceKey | KVAuthAPIToken | KVAuthEmailKey);


### PR DESCRIPTION
(credits to @atinux for noticing this)

According to [cloudflare docs](https://developers.cloudflare.com/kv/api/write-key-value-pairs/), the minimum amount of `ttl` is 60 seconds. This PR adds a fix to make sure if ttl is set, it is a minimum of 60 seconds (configurable via `minTTL` if needed) instead of throwing error in production.

