### PR TITLE
fix: revert chokidar to v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "anymatch": "^3.1.3",
-    "chokidar": "^4.0.1",
+    "chokidar": "^3.6.0",
     "citty": "^0.1.6",
     "destr": "^2.0.3",
     "h3": "^1.13.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^3.1.3
         version: 3.1.3
       chokidar:
-        specifier: ^4.0.1
-        version: 4.0.1
+        specifier: ^3.6.0
+        version: 3.6.0
       citty:
         specifier: ^0.1.6
         version: 0.1.6
@@ -1590,10 +1590,6 @@ packages:
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
     engines: {node: '>= 8.10.0'}
-
-  chokidar@4.0.1:
-    resolution: {integrity: sha512-n8enUVCED/KVRQlab1hr3MVpcVMvxtZjmEa956u+4YijlmQED223XMSYj2tLuKvr4jcCTzNNMpQDUer72MMmzA==}
-    engines: {node: '>= 14.16.0'}
 
   chownr@2.0.0:
     resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
@@ -3581,10 +3577,6 @@ packages:
   readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
-
-  readdirp@4.0.2:
-    resolution: {integrity: sha512-yDMz9g+VaZkqBYS/ozoBJwaBhTbZo3UNYQHNRw1D3UFQB8oHB4uS/tAODO+ZLjGWmUbKnIlOWO+aaIiAxrUWHA==}
-    engines: {node: '>= 14.16.0'}
 
   readline-sync@1.4.10:
     resolution: {integrity: sha512-gNva8/6UAe8QYepIQH/jQ2qn91Qj0B9sYjMBBs3QOB8F2CXcKgLxQaJRP76sWVRQt+QU+8fAkCbCvjjMFu7Ycw==}
@@ -5914,10 +5906,6 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  chokidar@4.0.1:
-    dependencies:
-      readdirp: 4.0.2
-
   chownr@2.0.0: {}
 
   ci-info@4.0.0: {}
@@ -8118,8 +8106,6 @@ snapshots:
   readdirp@3.6.0:
     dependencies:
       picomatch: 2.3.1
-
-  readdirp@4.0.2: {}
 
   readline-sync@1.4.10: {}
 

--- a/src/drivers/fs.ts
+++ b/src/drivers/fs.ts
@@ -1,6 +1,6 @@
 import { existsSync, promises as fsp, Stats } from "node:fs";
 import { resolve, relative, join } from "node:path";
-import { FSWatcher, ChokidarOptions, watch } from "chokidar";
+import { FSWatcher, WatchOptions as ChokidarOptions, watch } from "chokidar";
 import { createError, createRequiredError, defineDriver } from "./utils";
 import {
   readFile,


### PR DESCRIPTION
- https://github.com/nuxt/nuxt/issues/29744
- https://github.com/vitejs/vite/issues/18527

Revert Chokidar to v3 temporarily (updated in v1.13.0 via #489) due to downstream issues.
