### PR TITLE
cloudflareR2bindings: Fixed getItemRaw()

### DIFF
--- a/src/drivers/cloudflare-r2-binding.ts
+++ b/src/drivers/cloudflare-r2-binding.ts
@@ -50,7 +50,7 @@ export default defineDriver((opts: CloudflareR2Options = {}) => {
     getItemRaw(key, topts) {
       key = r(key);
       const binding = getR2Binding(opts.binding);
-      return binding.get(key, topts).then((r) => r?.arrayBuffer());
+      return binding.get(key, topts).then((r) => r?.body);
     },
     async setItem(key, value, topts) {
       key = r(key);


### PR DESCRIPTION
TLDR: Files saved to Cloudflare R2 were not returned correctly by `.getItemRaw()`, this PR fixes that.

---

I tried to save files into Cloudflare R2 from a Cloudflare worker by a binding. Saving was no problem by use of `.setItemRaw()`, the file was added correctly to R2. But getting the item I had weird results:

* `.getItem()` returns a string, e.g. when the file was a pdf, the response was the markup of the pdf as a string. (btw this is because it is calling `.text()`, not sure if this is usefull at all)
* `.getItemRaw()` returns an empty object

I checked [the docs](https://developers.cloudflare.com/r2/api/workers/workers-api-usage/#4-access-your-r2-bucket-from-your-worker) and they do it like this:

```ts
export default defineEventHandler(async (event) => {
    const object = await globalThis.__env__.BINDING.get('key')`
    return object.data;
});
```

In this example above, `object` is of type [R2ObjectBody](https://github.com/cloudflare/workers-types/blob/master/index.d.ts#L992), [reference is here](https://developers.cloudflare.com/r2/api/workers/workers-api-reference/#r2objectbody-definition)

In the [current implementation](https://github.com/unjs/unstorage/blob/main/src/drivers/cloudflare-r2-binding.ts#L53) `object.arrayBuffer()` is returned instead of `.body`. I am not exactly sure why the author chose to do that, because:

1. It doesnt work (i tried to return image and pdf)
2. I would expect a "raw" function not to call a function that obviously does transformations

Therefor I changed `getItemRaw()` to return `.body` which now returns files correctly.