### PR TITLE
feat(cloudflare-r2-binding): allow specify raw type

### DIFF
--- a/docs/2.drivers/cloudflare.md
+++ b/docs/2.drivers/cloudflare.md
@@ -163,6 +163,6 @@ const storage = createStorage({
 - `getItemRaw(key, { type: "..." })`
   - `type: "object"`: Return the [R2 object body](https://developers.cloudflare.com/r2/api/workers/workers-api-reference/#r2objectbody-definition).
   - `type: "stream"`: Return body stream.
-  - `type: "blob"`: Return data blobl.
+  - `type: "blob"`: Return a `Blob`.
   - `type: "bytes"`: Return an `Uint8Array`.
   - `type: "arrayBuffer"`: Return an `ArrayBuffer` (default)

--- a/docs/2.drivers/cloudflare.md
+++ b/docs/2.drivers/cloudflare.md
@@ -161,7 +161,7 @@ const storage = createStorage({
 **Transaction options:**
 
 - `getItemRaw(key, { type: "..." })`
-  - `type: "object"`: Return the [R2 object](https://developers.cloudflare.com/r2/api/workers/workers-api-reference/#r2objectbody-definition).
+  - `type: "object"`: Return the [R2 object body](https://developers.cloudflare.com/r2/api/workers/workers-api-reference/#r2objectbody-definition).
   - `type: "stream"`: Return body stream.
   - `type: "blob"`: Return data blobl.
   - `type: "bytes"`: Return an `Uint8Array`.

--- a/docs/2.drivers/cloudflare.md
+++ b/docs/2.drivers/cloudflare.md
@@ -157,3 +157,12 @@ const storage = createStorage({
 
 - `binding`: Bucket binding or name. Default is `BUCKET`.
 - `base`: Prefix all keys with base.
+
+**Transaction options:**
+
+- `getItemRaw(key, { type: "..." })`
+  - `type: "object"`: Return the [R2 object](https://developers.cloudflare.com/r2/api/workers/workers-api-reference/#r2objectbody-definition).
+  - `type: "stream"`: Return body stream.
+  - `type: "blob"`: Return data blobl.
+  - `type: "bytes"`: Return an `Uint8Array`.
+  - `type: "arrayBuffer"`: Return an `ArrayBuffer` (default)

--- a/test/drivers/cloudflare-r2-binding.test.ts
+++ b/test/drivers/cloudflare-r2-binding.test.ts
@@ -24,12 +24,13 @@ describe("drivers: cloudflare-r2-binding", async () => {
         const storageSnapshot = await snapshot(storage, "");
 
         storageSnapshot["base:data:raw.bin"] = (await storage.getItemRaw(
-          "base:data:raw.bin"
+          "base:data:raw.bin",
+          { type: "bytes" }
         )) as any;
 
         expect(storageSnapshot).toMatchInlineSnapshot(`
           {
-            "base:data:raw.bin": ArrayBuffer [
+            "base:data:raw.bin": Uint8Array [
               1,
               2,
               3,


### PR DESCRIPTION
(context: #517 by @MickL)

This PR allows `getItemRaw(key, { type: "..." })` with specified return type based on user needs: object/stream/blob/bytes/arrayBuffer are possible (check docs)