### PR TITLE
fix(http): return `arrayBuffer` for `getItemRaw`

### DIFF
--- a/src/drivers/http.ts
+++ b/src/drivers/http.ts
@@ -56,10 +56,13 @@ export default defineDriver((opts: HTTPOptions) => {
       return value;
     },
     async getItemRaw(key, topts) {
-      const value = await _fetch(r(key), {
-        headers: getHeaders(topts, { accept: "application/octet-stream" }),
-      }).catch(catchFetchError);
-      return value;
+      const response = await _fetch
+        .raw(r(key), {
+          responseType: "arrayBuffer",
+          headers: getHeaders(topts, { accept: "application/octet-stream" }),
+        })
+        .catch(catchFetchError);
+      return response._data;
     },
     async getMeta(key, topts) {
       const res = await _fetch.raw(r(key), {


### PR DESCRIPTION
(credits to @itpropro for dicovery in #364)

`getItemRaw` for `http` driver was using ofetch default (text string). This PR fixes to use `arrayBuffer` (consistent with most of other drivers raw value)