### PR TITLE
fix(localstorage): consider `base` for `clear` and `getKeys`

### DIFF
--- a/test/drivers/localstorage.test.ts
+++ b/test/drivers/localstorage.test.ts
@@ -9,11 +9,22 @@ describe("drivers: localstorage", () => {
   });
   jsdom.virtualConsole.sendTo(console);
 
+  jsdom.window.localStorage.setItem("__external_key__", "unrelated_data");
+
   testDriver({
-    driver: driver({ window: jsdom.window as unknown as typeof window }),
+    driver: driver({
+      window: jsdom.window as unknown as typeof window,
+      base: "test",
+    }),
     additionalTests: (ctx) => {
       it("check localstorage", () => {
-        expect(jsdom.window.localStorage.getItem("s1:a")).toBe("test_data");
+        expect(jsdom.window.localStorage.getItem("test:s1:a")).toBe(
+          "test_data"
+        );
+        ctx.driver.clear!("", {});
+        expect(jsdom.window.localStorage.getItem("__external_key__")).toBe(
+          "unrelated_data"
+        );
       });
       it("watch localstorage", async () => {
         const watcher = vi.fn();

--- a/test/drivers/localstorage.test.ts
+++ b/test/drivers/localstorage.test.ts
@@ -17,11 +17,11 @@ describe("drivers: localstorage", () => {
       base: "test",
     }),
     additionalTests: (ctx) => {
-      it("check localstorage", () => {
+      it("check localstorage", async () => {
         expect(jsdom.window.localStorage.getItem("test:s1:a")).toBe(
           "test_data"
         );
-        ctx.driver.clear!("", {});
+        await ctx.driver.clear!("", {});
         expect(jsdom.window.localStorage.getItem("__external_key__")).toBe(
           "unrelated_data"
         );


### PR DESCRIPTION
resolves #352

(fix added to localstorage only since merging it to webstorge in #338)