### PR TITLE
refactor: reuse `localstorage` logic for `session-storage`

### DIFF
--- a/docs/2.drivers/browser.md
+++ b/docs/2.drivers/browser.md
@@ -4,17 +4,13 @@ icon: ph:browser-thin
 
 # Browser
 
-> Browser based storages.
+> Store data in `localStorage`, `sessionStorage` or `IndexedDB`
 
-## Local Storage
-
-Store data in localStorage.
+## LocalStorage / SessionStorage
 
 ### Usage
 
-::read-more{to="https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage"}
-Learn more about localStorage.
-::
+Store data in [localStorage](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage) or [sessionStorage](https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage.)
 
 ```js
 import { createStorage } from "unstorage";
@@ -27,32 +23,10 @@ const storage = createStorage({
 
 **Options:**
 
-- `base`: Add `${base}:` to all keys to avoid collision
-- `localStorage`: Optionally provide `localStorage` object
-- `window`: Optionally provide `window` object
-
-## Session Storage
-
-> Store data in sessionStorage.
-
-::read-more{to="https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage"}
-Learn more about sessionStorage.
-::
-
-```js
-import { createStorage } from "unstorage";
-import sessionStorageDriver from "unstorage/drivers/session-storage";
-
-const storage = createStorage({
-  driver: sessionStorageDriver({ base: "app:" }),
-});
-```
-
-**Options:**
-
-- `base`: Add `${base}:` to all keys to avoid collision
-- `sessionStorage`: Optionally provide `sessionStorage` object
-- `window`: Optionally provide `window` object
+- `base`: Add base to all keys to avoid collision
+- `storage`: (optional) provide `localStorage` or `sessionStorage` compatible object.
+- `windowKey`: (optional) Can be `"localStorage"` (default) or `"sessionStorage"`
+- `window`: (optional) provide `window` object
 
 ## IndexedDB
 

--- a/src/drivers/session-storage.ts
+++ b/src/drivers/session-storage.ts
@@ -1,77 +1,16 @@
-import { createRequiredError, defineDriver } from "./utils";
+import { defineDriver } from "./utils";
+import localstorage, { type LocalStorageOptions } from "./localstorage";
 
-export interface SessionStorageOptions {
-  base?: string;
-  window?: typeof window;
-  sessionStorage?: typeof window.sessionStorage;
-}
+export interface SessionStorageOptions extends LocalStorageOptions {}
 
 const DRIVER_NAME = "session-storage";
 
 export default defineDriver((opts: SessionStorageOptions = {}) => {
-  if (!opts.window) {
-    opts.window = typeof window === "undefined" ? undefined : window;
-  }
-  if (!opts.sessionStorage) {
-    opts.sessionStorage = opts.window?.sessionStorage;
-  }
-  if (!opts.sessionStorage) {
-    throw createRequiredError(DRIVER_NAME, "sessionStorage");
-  }
-
-  const r = (key: string) => (opts.base ? opts.base + ":" : "") + key;
-
-  let _storageListener: undefined | ((ev: StorageEvent) => void);
-  const _unwatch = () => {
-    if (_storageListener) {
-      opts.window!.removeEventListener("storage", _storageListener);
-    }
-    _storageListener = undefined;
-  };
-
   return {
     name: DRIVER_NAME,
-    options: opts,
-    getInstance: () => opts.sessionStorage!,
-    hasItem(key) {
-      return Object.prototype.hasOwnProperty.call(opts.sessionStorage, r(key));
-    },
-    getItem(key) {
-      return opts.sessionStorage!.getItem(r(key));
-    },
-    setItem(key, value) {
-      return opts.sessionStorage!.setItem(r(key), value);
-    },
-    removeItem(key) {
-      return opts.sessionStorage!.removeItem(r(key));
-    },
-    getKeys() {
-      return Object.keys(opts.sessionStorage!);
-    },
-    clear() {
-      if (opts.base) {
-        for (const key of Object.keys(opts.sessionStorage!)) {
-          opts.sessionStorage?.removeItem(key);
-        }
-      } else {
-        opts.sessionStorage!.clear();
-      }
-      if (opts.window && _storageListener) {
-        opts.window.removeEventListener("storage", _storageListener);
-      }
-    },
-    watch(callback) {
-      if (!opts.window) {
-        return _unwatch;
-      }
-      _storageListener = ({ key, newValue }: StorageEvent) => {
-        if (key) {
-          callback(newValue ? "update" : "remove", key);
-        }
-      };
-      opts.window!.addEventListener("storage", _storageListener);
-
-      return _unwatch;
-    },
+    ...localstorage({
+      windowKey: "sessionStorage",
+      ...opts,
+    }),
   };
 });


### PR DESCRIPTION
resolves #203 (rework of #338 -- by @thecotne ❤️)

session-storage logic is almost identical to localstorage driver. this PR reuses same logic of localstorage and adds generic options.