### PR TITLE
fix(types): fallback to `StorageValue` for un-typed stores

### DIFF
--- a/src/storage.ts
+++ b/src/storage.ts
@@ -170,8 +170,8 @@ export function createStorage<
     getItem(key: string, opts = {}) {
       key = normalizeKey(key);
       const { relativeKey, driver } = getMount(key);
-      return asyncCall(driver.getItem, relativeKey, opts).then((value) =>
-        destr(value)
+      return asyncCall(driver.getItem, relativeKey, opts).then(
+        (value) => destr(value) as StorageValue
       );
     },
     getItems(

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -7,7 +7,6 @@ import type {
   StorageValue,
   WatchEvent,
   TransactionOptions,
-  DefaultStorageDefinition,
 } from "./types";
 import memory from "./drivers/memory";
 import { asyncCall, deserializeRaw, serializeRaw, stringify } from "./_utils";
@@ -25,9 +24,9 @@ export interface CreateStorageOptions {
   driver?: Driver;
 }
 
-export function createStorage<
-  T extends StorageValue = DefaultStorageDefinition,
->(options: CreateStorageOptions = {}): Storage<T> {
+export function createStorage<T extends StorageValue>(
+  options: CreateStorageOptions = {}
+): Storage<T> {
   const context: StorageCTX = {
     mounts: { "": options.driver || memory() },
     mountpoints: [""],
@@ -470,7 +469,7 @@ export function createStorage<
     remove: (key: string, opts = {}) => storage.removeItem(key, opts),
   };
 
-  return storage;
+  return storage as unknown as Storage<T>;
 }
 
 export type Snapshot<T = string> = Record<string, T>;

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -7,6 +7,7 @@ import type {
   StorageValue,
   WatchEvent,
   TransactionOptions,
+  DefaultStorageDefinition,
 } from "./types";
 import memory from "./drivers/memory";
 import { asyncCall, deserializeRaw, serializeRaw, stringify } from "./_utils";
@@ -24,9 +25,9 @@ export interface CreateStorageOptions {
   driver?: Driver;
 }
 
-export function createStorage<T extends StorageValue>(
-  options: CreateStorageOptions = {}
-): Storage<T> {
+export function createStorage<
+  T extends StorageValue = DefaultStorageDefinition,
+>(options: CreateStorageOptions = {}): Storage<T> {
   const context: StorageCTX = {
     mounts: { "": options.driver || memory() },
     mountpoints: [""],

--- a/src/types.ts
+++ b/src/types.ts
@@ -66,9 +66,14 @@ type StorageDefinition = {
   [key: string]: unknown;
 };
 
+export type DefaultStorageDefinition = {
+  items: { [key: string]: StorageValue };
+  [key: string]: unknown;
+};
+
 type StorageItemMap<T extends StorageDefinition> = T["items"];
 
-export interface Storage<T extends StorageValue = StorageValue> {
+export interface Storage<T extends StorageValue = DefaultStorageDefinition> {
   // Item
   hasItem<
     U extends Extract<T, StorageDefinition>,
@@ -86,10 +91,10 @@ export interface Storage<T extends StorageValue = StorageValue> {
     key: K,
     ops?: TransactionOptions
   ): Promise<StorageItemMap<U>[K] | null>;
-  getItem<U extends T>(
+  getItem<_U extends T>(
     key: string,
     opts?: TransactionOptions
-  ): Promise<U | null>;
+  ): Promise<StorageValue | null>;
 
   /** @experimental */
   getItems: <U extends T>(

--- a/src/types.ts
+++ b/src/types.ts
@@ -66,14 +66,14 @@ type StorageDefinition = {
   [key: string]: unknown;
 };
 
-export type DefaultStorageDefinition = {
-  items: { [key: string]: StorageValue };
-  [key: string]: unknown;
-};
+type StorageItemMap<T> = T extends StorageDefinition ? T["items"] : T;
+type StorageItemType<T, K> = K extends keyof StorageItemMap<T>
+  ? StorageItemMap<T>[K]
+  : T extends StorageDefinition
+    ? StorageValue
+    : T;
 
-type StorageItemMap<T extends StorageDefinition> = T["items"];
-
-export interface Storage<T extends StorageValue = DefaultStorageDefinition> {
+export interface Storage<T extends StorageValue = StorageValue> {
   // Item
   hasItem<
     U extends Extract<T, StorageDefinition>,
@@ -86,15 +86,15 @@ export interface Storage<T extends StorageValue = DefaultStorageDefinition> {
 
   getItem<
     U extends Extract<T, StorageDefinition>,
-    K extends keyof StorageItemMap<U>,
+    K extends string & keyof StorageItemMap<U>,
   >(
     key: K,
     ops?: TransactionOptions
-  ): Promise<StorageItemMap<U>[K] | null>;
-  getItem<_U extends T>(
+  ): Promise<StorageItemType<T, K> | null>;
+  getItem(
     key: string,
     opts?: TransactionOptions
-  ): Promise<StorageValue | null>;
+  ): Promise<StorageItemType<T, string> | null>;
 
   /** @experimental */
   getItems: <U extends T>(
@@ -112,7 +112,7 @@ export interface Storage<T extends StorageValue = DefaultStorageDefinition> {
     K extends keyof StorageItemMap<U>,
   >(
     key: K,
-    value: StorageItemMap<U>[K],
+    value: StorageItemType<T, K>,
     opts?: TransactionOptions
   ): Promise<void>;
   setItem<U extends T>(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -26,7 +26,7 @@ export function prefixStorage<T extends StorageValue>(
   if (!base) {
     return storage;
   }
-  const nsStorage: Storage = { ...storage };
+  const nsStorage: Storage<T> = { ...storage };
   for (const property of storageKeyProperties) {
     // @ts-ignore
     nsStorage[property] = (key = "", ...args) =>

--- a/test/storage.test-d.ts
+++ b/test/storage.test-d.ts
@@ -9,9 +9,21 @@ describe("types", () => {
     expectTypeOf(
       await storage.getItem("foo")
     ).toEqualTypeOf<StorageValue | null>();
-    expectTypeOf(await storage.get("baz")).toEqualTypeOf<StorageValue | null>();
 
     await storage.setItem("foo", "str");
+    await storage.set("bar", 1);
+    await storage.removeItem("foo");
+    await storage.remove("bar");
+    await storage.del("baz");
+  });
+
+  it("indexed types for storage", async () => {
+    const storage = createStorage<string>();
+
+    expectTypeOf(await storage.getItem("foo")).toEqualTypeOf<string | null>();
+
+    await storage.setItem("foo", "str");
+    // @ts-expect-error should be a string
     await storage.set("bar", 1);
 
     await storage.removeItem("foo");

--- a/test/storage.test-d.ts
+++ b/test/storage.test-d.ts
@@ -3,7 +3,23 @@ import { createStorage } from "../src";
 import type { StorageValue } from "../src";
 
 describe("types", () => {
-  it("check types", async () => {
+  it("default types for storage", async () => {
+    const storage = createStorage();
+
+    expectTypeOf(
+      await storage.getItem("foo")
+    ).toEqualTypeOf<StorageValue | null>();
+    expectTypeOf(await storage.get("baz")).toEqualTypeOf<StorageValue | null>();
+
+    await storage.setItem("foo", "str");
+    await storage.set("bar", 1);
+
+    await storage.removeItem("foo");
+    await storage.remove("bar");
+    await storage.del("baz");
+  });
+
+  it("namespaced types for storage", async () => {
     type TestObjType = {
       a: number;
       b: boolean;
@@ -17,15 +33,12 @@ describe("types", () => {
     };
     const storage = createStorage<MyStorage>();
 
-    expectTypeOf(await storage.getItem("foo")).toMatchTypeOf<string | null>();
-    expectTypeOf(await storage.getItem("bar")).toMatchTypeOf<number | null>();
+    expectTypeOf(await storage.getItem("foo")).toEqualTypeOf<string | null>();
+    expectTypeOf(await storage.getItem("bar")).toEqualTypeOf<number | null>();
     expectTypeOf(
       await storage.getItem("unknown")
-    ).toMatchTypeOf<StorageValue | null>();
-    expectTypeOf(await storage.get("baz")).toMatchTypeOf<TestObjType | null>();
-    expectTypeOf(
-      await storage.getItem("aaaaa")
-    ).toMatchTypeOf<MyStorage | null>();
+    ).toEqualTypeOf<StorageValue | null>();
+    expectTypeOf(await storage.get("baz")).toEqualTypeOf<TestObjType | null>();
 
     // @ts-expect-error
     await storage.setItem("foo", 1); // ts err: Argument of type 'number' is not assignable to parameter of type 'string'


### PR DESCRIPTION
resolves https://github.com/unjs/unstorage/issues/531

we didn't catch the issue because `toMatchTypeOf` doesn't mean what it sounds like