### PR TITLE
fix(s3): use `/` as separator

### DIFF
--- a/src/drivers/s3.ts
+++ b/src/drivers/s3.ts
@@ -74,7 +74,7 @@ export default defineDriver((options: S3DriverOptions) => {
 
   const baseURL = `${options.endpoint.replace(/\/$/, "")}/${options.bucket || ""}`;
 
-  const url = (key: string = "") => `${baseURL}/${normalizeKey(key)}`;
+  const url = (key: string = "") => `${baseURL}/${normalizeKey(key, "/")}`;
 
   const awsFetch = async (url: string, opts?: RequestInit) => {
     const request = await getAwsClient().sign(url, opts);

--- a/src/drivers/utils/index.ts
+++ b/src/drivers/utils/index.ts
@@ -11,11 +11,14 @@ export function defineDriver<OptionsT = any, InstanceT = never>(
   return factory;
 }
 
-export function normalizeKey(key: string | undefined): string {
+export function normalizeKey(
+  key: string | undefined,
+  sep: ":" | "/" = ":"
+): string {
   if (!key) {
     return "";
   }
-  return key.replace(/[/\\]/g, ":").replace(/^:|:$/g, "");
+  return key.replace(/[:/\\]/g, sep).replace(/^[:/\\]|[:/\\]$/g, "");
 }
 
 export function joinKeys(...keys: string[]) {


### PR DESCRIPTION
resolves #544

s3 urls should use `/` as sep for external compatibility.