### PR TITLE
feat: add `depth` option to `getKeys`

### DIFF
--- a/src/drivers/azure-storage-blob.ts
+++ b/src/drivers/azure-storage-blob.ts
@@ -36,6 +36,47 @@ export interface AzureStorageBlobOptions {
 
 const DRIVER_NAME = "azure-storage-blob";
 
+async function getKeysByDepth(
+  client: ContainerClient,
+  depth: number
+): Promise<string[]> {
+  const queue: Array<{ depth: number; name: string }> = [];
+  let current: { depth: number; name: string } | undefined = {
+    name: "",
+    depth: 0,
+  };
+  const keys: string[] = [];
+
+  do {
+    const iterator = client
+      .listBlobsByHierarchy("/", {
+        prefix: current.name,
+      })
+      .byPage({ maxPageSize: 1000 });
+
+    for await (const result of iterator) {
+      const { blobPrefixes, blobItems } = result.segment;
+
+      if (blobPrefixes && current.depth < depth) {
+        for (const childPrefix of blobPrefixes) {
+          queue.push({
+            name: `${current.name}${childPrefix}`,
+            depth: current.depth + 1,
+          });
+        }
+      }
+
+      for (const item of blobItems) {
+        keys.push(item.name);
+      }
+    }
+
+    current = queue.pop();
+  } while (current !== undefined);
+
+  return keys;
+}
+
 export default defineDriver((opts: AzureStorageBlobOptions) => {
   let containerClient: ContainerClient;
   const getContainerClient = () => {
@@ -108,7 +149,11 @@ export default defineDriver((opts: AzureStorageBlobOptions) => {
     async removeItem(key) {
       await getContainerClient().getBlockBlobClient(key).delete();
     },
-    async getKeys() {
+    async getKeys(_base, opts) {
+      if (opts?.depth !== undefined) {
+        return getKeysByDepth(getContainerClient(), opts.depth);
+      }
+
       const iterator = getContainerClient()
         .listBlobsFlat()
         .byPage({ maxPageSize: 1000 });

--- a/src/drivers/fs-lite.ts
+++ b/src/drivers/fs-lite.ts
@@ -73,8 +73,8 @@ export default defineDriver((opts: FSStorageOptions = {}) => {
       }
       return unlink(r(key));
     },
-    getKeys() {
-      return readdirRecursive(r("."), opts.ignore);
+    getKeys(_base, { depth }) {
+      return readdirRecursive(r("."), opts.ignore, depth);
     },
     async clear() {
       if (opts.readOnly || opts.noClear) {

--- a/src/drivers/fs.ts
+++ b/src/drivers/fs.ts
@@ -92,8 +92,8 @@ export default defineDriver((opts: FSStorageOptions = {}) => {
       }
       return unlink(r(key));
     },
-    getKeys() {
-      return readdirRecursive(r("."), anymatch(opts.ignore || []));
+    getKeys(_base, { depth }) {
+      return readdirRecursive(r("."), anymatch(opts.ignore || []), depth);
     },
     async clear() {
       if (opts.readOnly || opts.noClear) {

--- a/src/drivers/netlify-blobs.ts
+++ b/src/drivers/netlify-blobs.ts
@@ -1,10 +1,10 @@
 import { createError, createRequiredError, defineDriver } from "./utils";
+import { type GetKeysOptions } from "../types";
 import { getStore, getDeployStore } from "@netlify/blobs";
 import type {
   Store,
   BlobResponseType,
   SetOptions,
-  ListOptions,
   GetStoreOptions,
   GetDeployStoreOptions,
 } from "@netlify/blobs";
@@ -96,10 +96,7 @@ export default defineDriver((options: NetlifyStoreOptions) => {
     removeItem(key) {
       return getClient().delete(key);
     },
-    async getKeys(
-      base?: string,
-      tops?: Omit<ListOptions, "prefix" | "paginate">
-    ) {
+    async getKeys(base?: string, tops?: GetKeysOptions) {
       return (await getClient().list({ ...tops, prefix: base })).blobs.map(
         (item) => item.key
       );

--- a/src/drivers/utils/node-fs.ts
+++ b/src/drivers/utils/node-fs.ts
@@ -48,7 +48,8 @@ export async function ensuredir(dir: string) {
 
 export async function readdirRecursive(
   dir: string,
-  ignore?: (p: string) => boolean
+  ignore?: (p: string) => boolean,
+  maxDepth?: number
 ) {
   if (ignore && ignore(dir)) {
     return [];
@@ -59,8 +60,14 @@ export async function readdirRecursive(
     entries.map(async (entry) => {
       const entryPath = resolve(dir, entry.name);
       if (entry.isDirectory()) {
-        const dirFiles = await readdirRecursive(entryPath, ignore);
-        files.push(...dirFiles.map((f) => entry.name + "/" + f));
+        if (maxDepth === undefined || maxDepth > 0) {
+          const dirFiles = await readdirRecursive(
+            entryPath,
+            ignore,
+            maxDepth === undefined ? undefined : maxDepth - 1
+          );
+          files.push(...dirFiles.map((f) => entry.name + "/" + f));
+        }
       } else {
         if (!(ignore && ignore(entry.name))) {
           files.push(entry.name);

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,6 +18,10 @@ export interface StorageMeta {
 // TODO: type ttl
 export type TransactionOptions = Record<string, any>;
 
+export type GetKeysOptions = TransactionOptions & {
+  depth?: number;
+};
+
 export interface Driver<OptionsT = any, InstanceT = any> {
   name?: string;
   options?: OptionsT;
@@ -55,7 +59,7 @@ export interface Driver<OptionsT = any, InstanceT = any> {
     key: string,
     opts: TransactionOptions
   ) => MaybePromise<StorageMeta | null>;
-  getKeys: (base: string, opts: TransactionOptions) => MaybePromise<string[]>;
+  getKeys: (base: string, opts: GetKeysOptions) => MaybePromise<string[]>;
   clear?: (base: string, opts: TransactionOptions) => MaybePromise<void>;
   dispose?: () => MaybePromise<void>;
   watch?: (callback: WatchCallback) => MaybePromise<Unwatch>;
@@ -163,7 +167,7 @@ export interface Storage<T extends StorageValue = StorageValue> {
   ) => Promise<void>;
   removeMeta: (key: string, opts?: TransactionOptions) => Promise<void>;
   // Keys
-  getKeys: (base?: string, opts?: TransactionOptions) => Promise<string[]>;
+  getKeys: (base?: string, opts?: GetKeysOptions) => Promise<string[]>;
   // Utils
   clear: (base?: string, opts?: TransactionOptions) => Promise<void>;
   dispose: () => Promise<void>;

--- a/test/drivers/azure-storage-blob.test.ts
+++ b/test/drivers/azure-storage-blob.test.ts
@@ -1,4 +1,4 @@
-import { describe, beforeAll, afterAll } from "vitest";
+import { describe, beforeAll, afterAll, it, expect } from "vitest";
 import driver from "../../src/drivers/azure-storage-blob";
 import { testDriver } from "./utils";
 import { BlobServiceClient } from "@azure/storage-blob";
@@ -22,5 +22,35 @@ describe.skip("drivers: azure-storage-blob", () => {
       connectionString: "UseDevelopmentStorage=true",
       accountName: "local",
     }),
+    additionalTests(ctx) {
+      it("supports depth in getKeys", async () => {
+        await ctx.storage.setItem("depth-test/key0", "boop");
+        await ctx.storage.setItem("depth-test/depth0/key1", "boop");
+        await ctx.storage.setItem("depth-test/depth0/depth1/key2", "boop");
+        await ctx.storage.setItem("depth-test/depth0/depth1/key3", "boop");
+
+        const depth1Result = await ctx.storage.getKeys(undefined, {
+          depth: 1,
+        });
+        const depth2Result = await ctx.storage.getKeys(undefined, {
+          depth: 2,
+        });
+
+        expect(depth1Result).includes.members(["depth-test:key0"]);
+        expect(depth1Result).not.include.members([
+          "depth-test:depth0:key1",
+          "depth-test:depth0:depth1:key2",
+          "depth-test:depth0:depth1:key3",
+        ]);
+        expect(depth2Result).includes.members([
+          "depth-test:key0",
+          "depth-test:depth0:key1",
+        ]);
+        expect(depth2Result).not.include.members([
+          "depth-test:depth0:depth1:key2",
+          "depth-test:depth0:depth1:key3",
+        ]);
+      });
+    },
   });
 });

--- a/test/drivers/fs-lite.test.ts
+++ b/test/drivers/fs-lite.test.ts
@@ -31,6 +31,35 @@ describe("drivers: fs-lite", () => {
         await ctx.storage.setItem("s1/te..st..js", "ok");
         expect(await ctx.storage.getItem("s1/te..st..js")).toBe("ok");
       });
+
+      it("supports depth in getKeys", async () => {
+        await ctx.storage.setItem("depth-test/file0.md", "boop");
+        await ctx.storage.setItem("depth-test/depth0/file1.md", "boop");
+        await ctx.storage.setItem("depth-test/depth0/depth1/file2.md", "boop");
+        await ctx.storage.setItem("depth-test/depth0/depth1/file3.md", "boop");
+
+        const depth1Result = await ctx.storage.getKeys(undefined, {
+          depth: 1,
+        });
+        const depth2Result = await ctx.storage.getKeys(undefined, {
+          depth: 2,
+        });
+
+        expect(depth1Result).includes.members(["depth-test:file0.md"]);
+        expect(depth1Result).not.include.members([
+          "depth-test:depth0:file1.md",
+          "depth-test:depth0:depth1:file2.md",
+          "depth-test:depth0:depth1:file3.md",
+        ]);
+        expect(depth2Result).includes.members([
+          "depth-test:file0.md",
+          "depth-test:depth0:file1.md",
+        ]);
+        expect(depth2Result).not.include.members([
+          "depth-test:depth0:depth1:file2.md",
+          "depth-test:depth0:depth1:file3.md",
+        ]);
+      });
     },
   });
 });

--- a/test/drivers/fs.test.ts
+++ b/test/drivers/fs.test.ts
@@ -38,6 +38,35 @@ describe("drivers: fs", () => {
         await ctx.storage.setItem("s1/te..st..js", "ok");
         expect(await ctx.storage.getItem("s1/te..st..js")).toBe("ok");
       });
+
+      it("supports depth in getKeys", async () => {
+        await ctx.storage.setItem("depth-test/file0.md", "boop");
+        await ctx.storage.setItem("depth-test/depth0/file1.md", "boop");
+        await ctx.storage.setItem("depth-test/depth0/depth1/file2.md", "boop");
+        await ctx.storage.setItem("depth-test/depth0/depth1/file3.md", "boop");
+
+        const depth1Result = await ctx.storage.getKeys(undefined, {
+          depth: 1,
+        });
+        const depth2Result = await ctx.storage.getKeys(undefined, {
+          depth: 2,
+        });
+
+        expect(depth1Result).includes.members(["depth-test:file0.md"]);
+        expect(depth1Result).not.include.members([
+          "depth-test:depth0:file1.md",
+          "depth-test:depth0:depth1:file2.md",
+          "depth-test:depth0:depth1:file3.md",
+        ]);
+        expect(depth2Result).includes.members([
+          "depth-test:file0.md",
+          "depth-test:depth0:file1.md",
+        ]);
+        expect(depth2Result).not.include.members([
+          "depth-test:depth0:depth1:file2.md",
+          "depth-test:depth0:depth1:file3.md",
+        ]);
+      });
     },
   });
 });


### PR DESCRIPTION
Adds a new `depth` option to the `getKeys` signature.

Also implements that option in the following drivers:

- `fs`
- `fs-lite`
- `azure-storage-blob`

Fixes #539

Let me know if this is the kind of implementation you had in mind @pi0 

While I was wandering around the fs code, I did also get somewhat confused by `base` in `getKeys(base)`. It is probably me misunderstanding, but if I do `getKeys("subdir")`, I assumed I'd get all the files in `{root}/subdir` and below. However, it seems the current impl ignores `base` and hard codes `.` for traversal

Changing that to `base ?? "."` breaks some tests, though. it also results in some keys being dropped in the test driver/harness because it expects the keys to be `{base}{key}`, which isn't true in the fs driver it seems