### PR TITLE
test: clear storage after each test

### DIFF
--- a/test/drivers/cloudflare-kv-binding.test.ts
+++ b/test/drivers/cloudflare-kv-binding.test.ts
@@ -14,33 +14,20 @@ describe("drivers: cloudflare-kv", async () => {
   });
   testDriver({
     driver: CloudflareKVBinding({ base: "base" }),
-    async additionalTests() {
+    async additionalTests(ctx) {
       test("snapshot", async () => {
+        await ctx.storage.setItem("s1:a", "test_data");
+        await ctx.storage.setItem("s2:a", "test_data");
+        await ctx.storage.setItem("s3:a", "test_data");
+
         const storage = createStorage({
           driver: CloudflareKVBinding({}),
         });
         expect(await snapshot(storage, "")).toMatchInlineSnapshot(`
           {
-            "base:data:raw.bin": "base64:AQID",
-            "base:data:serialized1.json": "SERIALIZED",
-            "base:data:serialized2.json": {
-              "serializedObj": "works",
-            },
-            "base:data:test.json": {
-              "json": "works",
-            },
-            "base:data:true.json": true,
-            "base:my-false-flag": false,
             "base:s1:a": "test_data",
             "base:s2:a": "test_data",
             "base:s3:a": "test_data",
-            "base:t:1": "test_data_t1",
-            "base:t:2": "test_data_t2",
-            "base:t:3": "test_data_t3",
-            "base:v1:a": "test_data_v1:a",
-            "base:v2:a": "test_data_v2:a",
-            "base:v3:a": "test_data_v3:a?q=1",
-            "base:zero": 0,
           }
         `);
       });

--- a/test/drivers/cloudflare-r2-binding.test.ts
+++ b/test/drivers/cloudflare-r2-binding.test.ts
@@ -15,45 +15,23 @@ describe("drivers: cloudflare-r2-binding", async () => {
 
   testDriver({
     driver: CloudflareR2Binding({ base: "base" }),
-    async additionalTests() {
+    async additionalTests(ctx) {
       test("snapshot", async () => {
+        await ctx.storage.setItem("s1:a", "test_data");
+        await ctx.storage.setItem("s2:a", "test_data");
+        await ctx.storage.setItem("s3:a", "test_data");
+
         const storage = createStorage({
           driver: CloudflareR2Binding({}),
         });
 
         const storageSnapshot = await snapshot(storage, "");
 
-        storageSnapshot["base:data:raw.bin"] = (await storage.getItemRaw(
-          "base:data:raw.bin",
-          { type: "bytes" }
-        )) as any;
-
         expect(storageSnapshot).toMatchInlineSnapshot(`
           {
-            "base:data:raw.bin": Uint8Array [
-              1,
-              2,
-              3,
-            ],
-            "base:data:serialized1.json": "SERIALIZED",
-            "base:data:serialized2.json": {
-              "serializedObj": "works",
-            },
-            "base:data:test.json": {
-              "json": "works",
-            },
-            "base:data:true.json": true,
-            "base:my-false-flag": false,
             "base:s1:a": "test_data",
             "base:s2:a": "test_data",
             "base:s3:a": "test_data",
-            "base:t:1": "test_data_t1",
-            "base:t:2": "test_data_t2",
-            "base:t:3": "test_data_t3",
-            "base:v1:a": "test_data_v1:a",
-            "base:v2:a": "test_data_v2:a",
-            "base:v3:a": "test_data_v3:a?q=1",
-            "base:zero": 0,
           }
         `);
       });

--- a/test/drivers/fs-lite.test.ts
+++ b/test/drivers/fs-lite.test.ts
@@ -11,9 +11,11 @@ describe("drivers: fs-lite", () => {
     driver: driver({ base: dir }),
     additionalTests(ctx) {
       it("check filesystem", async () => {
+        await ctx.storage.setItem("s1:a", "test_data");
         expect(await readFile(resolve(dir, "s1/a"), "utf8")).toBe("test_data");
       });
       it("native meta", async () => {
+        await ctx.storage.setItem("s1:a", "test_data");
         const meta = await ctx.storage.getMeta("/s1/a");
         expect(meta.atime?.constructor.name).toBe("Date");
         expect(meta.mtime?.constructor.name).toBe("Date");

--- a/test/drivers/fs.test.ts
+++ b/test/drivers/fs.test.ts
@@ -11,9 +11,11 @@ describe("drivers: fs", () => {
     driver: driver({ base: dir }),
     additionalTests(ctx) {
       it("check filesystem", async () => {
+        await ctx.storage.setItem("s1:a", "test_data");
         expect(await readFile(resolve(dir, "s1/a"), "utf8")).toBe("test_data");
       });
       it("native meta", async () => {
+        await ctx.storage.setItem("s1:a", "test_data");
         const meta = await ctx.storage.getMeta("/s1/a");
         expect(meta.atime?.constructor.name).toBe("Date");
         expect(meta.mtime?.constructor.name).toBe("Date");

--- a/test/drivers/localstorage.test.ts
+++ b/test/drivers/localstorage.test.ts
@@ -18,6 +18,7 @@ describe("drivers: localstorage", () => {
     }),
     additionalTests: (ctx) => {
       it("check localstorage", async () => {
+        await ctx.storage.setItem("s1:a", "test_data");
         expect(jsdom.window.localStorage.getItem("test:s1:a")).toBe(
           "test_data"
         );

--- a/test/drivers/redis.test.ts
+++ b/test/drivers/redis.test.ts
@@ -14,8 +14,12 @@ describe("drivers: redis", () => {
 
   testDriver({
     driver,
-    additionalTests() {
+    additionalTests(ctx) {
       it("verify stored keys", async () => {
+        await ctx.storage.setItem("s1:a", "test_data");
+        await ctx.storage.setItem("s2:a", "test_data");
+        await ctx.storage.setItem("s3:a?q=1", "test_data");
+
         const client = new ioredis.default("ioredis://localhost:6379/0");
         const keys = await client.keys("*");
         expect(keys).toMatchInlineSnapshot(`
@@ -23,19 +27,6 @@ describe("drivers: redis", () => {
             "test:s1:a",
             "test:s2:a",
             "test:s3:a",
-            "test:data:test.json",
-            "test:data:true.json",
-            "test:data:serialized1.json",
-            "test:data:serialized2.json",
-            "test:data:raw.bin",
-            "test:t:1",
-            "test:t:2",
-            "test:t:3",
-            "test:v1:a",
-            "test:v2:a",
-            "test:v3:a",
-            "test:zero",
-            "test:my-false-flag",
           ]
         `);
         await client.disconnect();

--- a/test/drivers/session-storage.test.ts
+++ b/test/drivers/session-storage.test.ts
@@ -12,7 +12,8 @@ describe("drivers: session-storage", () => {
   testDriver({
     driver: driver({ window: jsdom.window as unknown as typeof window }),
     additionalTests: (ctx) => {
-      it("check session storage", () => {
+      it("check session storage", async () => {
+        await ctx.storage.setItem("s1:a", "test_data");
         expect(jsdom.window.sessionStorage.getItem("s1:a")).toBe("test_data");
       });
       it("watch session storage", async () => {

--- a/test/drivers/utils.ts
+++ b/test/drivers/utils.ts
@@ -1,4 +1,4 @@
-import { it, expect, beforeAll, afterAll } from "vitest";
+import { it, expect, beforeAll, afterAll, afterEach } from "vitest";
 import {
   type Storage,
   type Driver,
@@ -33,6 +33,10 @@ export function testDriver(opts: TestOptions) {
     await ctx.storage?.dispose?.();
   });
 
+  afterEach(async () => {
+    await ctx.storage.clear();
+  });
+
   it("init", async () => {
     await restoreSnapshot(ctx.storage, { initial: "works" });
     expect(await ctx.storage.getItem("initial")).toBe("works");
@@ -55,6 +59,9 @@ export function testDriver(opts: TestOptions) {
   });
 
   it("getKeys", async () => {
+    await ctx.storage.setItem("s1:a", "test_data");
+    await ctx.storage.setItem("s2:a", "test_data");
+    await ctx.storage.setItem("s3:a?q=1", "test_data");
     expect(await ctx.storage.getKeys().then((k) => k.sort())).toMatchObject(
       ["s1:a", "s2:a", "s3:a"].sort()
     );


### PR DESCRIPTION
Clears the storage after each test such that they no longer rely on run order, etc.

Note that the two snapshot tests have been massively dumbed down. Though I'm not sure this is a problem since the underlying driver tests already test the data types etc. Leaving these to purely test that _a_ snapshot can be produced. 

let me know what you think