### PR TITLE
feat(fs, fs-lite): native `maxDepth` support

### DIFF
--- a/src/drivers/fs-lite.ts
+++ b/src/drivers/fs-lite.ts
@@ -73,8 +73,8 @@ export default defineDriver((opts: FSStorageOptions = {}) => {
       }
       return unlink(r(key));
     },
-    getKeys() {
-      return readdirRecursive(r("."), opts.ignore);
+    getKeys(_base, { maxDepth }) {
+      return readdirRecursive(r("."), opts.ignore, maxDepth);
     },
     async clear() {
       if (opts.readOnly || opts.noClear) {

--- a/src/drivers/fs-lite.ts
+++ b/src/drivers/fs-lite.ts
@@ -73,8 +73,8 @@ export default defineDriver((opts: FSStorageOptions = {}) => {
       }
       return unlink(r(key));
     },
-    getKeys(_base, { maxDepth }) {
-      return readdirRecursive(r("."), opts.ignore, maxDepth);
+    getKeys(_base, topts) {
+      return readdirRecursive(r("."), opts.ignore, topts?.maxDepth);
     },
     async clear() {
       if (opts.readOnly || opts.noClear) {

--- a/src/drivers/fs.ts
+++ b/src/drivers/fs.ts
@@ -92,8 +92,12 @@ export default defineDriver((opts: FSStorageOptions = {}) => {
       }
       return unlink(r(key));
     },
-    getKeys(_base, { maxDepth }) {
-      return readdirRecursive(r("."), anymatch(opts.ignore || []), maxDepth);
+    getKeys(_base, topts) {
+      return readdirRecursive(
+        r("."),
+        anymatch(opts.ignore || []),
+        topts?.maxDepth
+      );
     },
     async clear() {
       if (opts.readOnly || opts.noClear) {

--- a/src/drivers/fs.ts
+++ b/src/drivers/fs.ts
@@ -92,8 +92,8 @@ export default defineDriver((opts: FSStorageOptions = {}) => {
       }
       return unlink(r(key));
     },
-    getKeys() {
-      return readdirRecursive(r("."), anymatch(opts.ignore || []));
+    getKeys(_base, { maxDepth }) {
+      return readdirRecursive(r("."), anymatch(opts.ignore || []), maxDepth);
     },
     async clear() {
       if (opts.readOnly || opts.noClear) {

--- a/src/drivers/utils/node-fs.ts
+++ b/src/drivers/utils/node-fs.ts
@@ -48,7 +48,8 @@ export async function ensuredir(dir: string) {
 
 export async function readdirRecursive(
   dir: string,
-  ignore?: (p: string) => boolean
+  ignore?: (p: string) => boolean,
+  maxDepth?: number
 ) {
   if (ignore && ignore(dir)) {
     return [];
@@ -59,8 +60,14 @@ export async function readdirRecursive(
     entries.map(async (entry) => {
       const entryPath = resolve(dir, entry.name);
       if (entry.isDirectory()) {
-        const dirFiles = await readdirRecursive(entryPath, ignore);
-        files.push(...dirFiles.map((f) => entry.name + "/" + f));
+        if (maxDepth === undefined || maxDepth > 0) {
+          const dirFiles = await readdirRecursive(
+            entryPath,
+            ignore,
+            maxDepth === undefined ? undefined : maxDepth - 1
+          );
+          files.push(...dirFiles.map((f) => entry.name + "/" + f));
+        }
       } else {
         if (!(ignore && ignore(entry.name))) {
           files.push(entry.name);

--- a/test/drivers/fs-lite.test.ts
+++ b/test/drivers/fs-lite.test.ts
@@ -34,32 +34,37 @@ describe("drivers: fs-lite", () => {
         expect(await ctx.storage.getItem("s1/te..st..js")).toBe("ok");
       });
 
-      it("supports depth in getKeys", async () => {
-        await ctx.storage.setItem("depth-test/file0.md", "boop");
-        await ctx.storage.setItem("depth-test/depth0/file1.md", "boop");
-        await ctx.storage.setItem("depth-test/depth0/depth1/file2.md", "boop");
+      it("natively supports maxDepth in getKeys", async () => {
+        await ctx.storage.setItem("file0.md", "boop");
+        await ctx.storage.setItem("depth-test/file1.md", "boop");
+        await ctx.storage.setItem("depth-test/depth0/file2.md", "boop");
         await ctx.storage.setItem("depth-test/depth0/depth1/file3.md", "boop");
+        await ctx.storage.setItem("depth-test/depth0/depth1/file4.md", "boop");
 
-        const depth1Result = await ctx.storage.getKeys(undefined, {
-          depth: 1,
-        });
-        const depth2Result = await ctx.storage.getKeys(undefined, {
-          depth: 2,
-        });
-
-        expect(depth1Result).includes.members(["depth-test:file0.md"]);
-        expect(depth1Result).not.include.members([
-          "depth-test:depth0:file1.md",
-          "depth-test:depth0:depth1:file2.md",
-          "depth-test:depth0:depth1:file3.md",
-        ]);
-        expect(depth2Result).includes.members([
-          "depth-test:file0.md",
-          "depth-test:depth0:file1.md",
-        ]);
-        expect(depth2Result).not.include.members([
-          "depth-test:depth0:depth1:file2.md",
-          "depth-test:depth0:depth1:file3.md",
+        expect(
+          (
+            await ctx.driver.getKeys("", {
+              maxDepth: 0,
+            })
+          ).sort()
+        ).toMatchObject(["file0.md"]);
+        expect(
+          (
+            await ctx.driver.getKeys("", {
+              maxDepth: 1,
+            })
+          ).sort()
+        ).toMatchObject(["depth-test/file1.md", "file0.md"]);
+        expect(
+          (
+            await ctx.driver.getKeys("", {
+              maxDepth: 2,
+            })
+          ).sort()
+        ).toMatchObject([
+          "depth-test/depth0/file2.md",
+          "depth-test/file1.md",
+          "file0.md",
         ]);
       });
     },

--- a/test/drivers/fs-lite.test.ts
+++ b/test/drivers/fs-lite.test.ts
@@ -33,6 +33,35 @@ describe("drivers: fs-lite", () => {
         await ctx.storage.setItem("s1/te..st..js", "ok");
         expect(await ctx.storage.getItem("s1/te..st..js")).toBe("ok");
       });
+
+      it("supports depth in getKeys", async () => {
+        await ctx.storage.setItem("depth-test/file0.md", "boop");
+        await ctx.storage.setItem("depth-test/depth0/file1.md", "boop");
+        await ctx.storage.setItem("depth-test/depth0/depth1/file2.md", "boop");
+        await ctx.storage.setItem("depth-test/depth0/depth1/file3.md", "boop");
+
+        const depth1Result = await ctx.storage.getKeys(undefined, {
+          depth: 1,
+        });
+        const depth2Result = await ctx.storage.getKeys(undefined, {
+          depth: 2,
+        });
+
+        expect(depth1Result).includes.members(["depth-test:file0.md"]);
+        expect(depth1Result).not.include.members([
+          "depth-test:depth0:file1.md",
+          "depth-test:depth0:depth1:file2.md",
+          "depth-test:depth0:depth1:file3.md",
+        ]);
+        expect(depth2Result).includes.members([
+          "depth-test:file0.md",
+          "depth-test:depth0:file1.md",
+        ]);
+        expect(depth2Result).not.include.members([
+          "depth-test:depth0:depth1:file2.md",
+          "depth-test:depth0:depth1:file3.md",
+        ]);
+      });
     },
   });
 });

--- a/test/drivers/fs.test.ts
+++ b/test/drivers/fs.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
 import { resolve } from "node:path";
-import { stat } from "node:fs/promises";
 import { readFile, writeFile } from "../../src/drivers/utils/node-fs";
 import { testDriver } from "./utils";
 import driver from "../../src/drivers/fs";
@@ -48,32 +47,21 @@ describe("drivers: fs", () => {
         await ctx.storage.setItem("depth-test/depth0/depth1/file2.md", "boop");
         await ctx.storage.setItem("depth-test/depth0/depth1/file3.md", "boop");
 
-        const originalStat = await stat(
-          resolve(dir, "depth-test/depth0/file1.md")
-        );
-
         expect(
           (
-            await ctx.storage.getKeys(undefined, {
+            await ctx.driver.getKeys("", {
               maxDepth: 1,
             })
           ).sort()
-        ).toMatchObject(["depth-test:file0.md"]);
-
-        const newStat = await stat(resolve(dir, "depth-test/depth0/file1.md"));
-
-        // assert that the driver didn't access `file1.md`
-        // this tells us that the native filtering worked, rather than
-        // the higher level filter catching it
-        expect(originalStat.atime).toEqual(newStat.atime);
+        ).toMatchObject(["depth-test/file0.md"]);
 
         expect(
           (
-            await ctx.storage.getKeys(undefined, {
+            await ctx.driver.getKeys("", {
               maxDepth: 2,
             })
           ).sort()
-        ).toMatchObject(["depth-test:depth0:file1.md", "depth-test:file0.md"]);
+        ).toMatchObject(["depth-test/depth0/file1.md", "depth-test/file0.md"]);
       });
     },
   });


### PR DESCRIPTION
Adds native support for `maxDepth` to the `fs` and `fs-lite` drivers.

This works by traversing directories only until the depth has been met.