### PR TITLE
feat: add `flags` key to driver interface

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -23,7 +23,8 @@ export type GetKeysOptions = TransactionOptions & {
 };
 
 export interface DriverFlags {
-  supportsMaxDepth?: boolean;
+  maxDepth?: boolean;
+  ttl?: boolean;
 }
 
 export interface Driver<OptionsT = any, InstanceT = any> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,8 +22,13 @@ export type GetKeysOptions = TransactionOptions & {
   maxDepth?: number;
 };
 
+export interface DriverFlags {
+  supportsMaxDepth?: boolean;
+}
+
 export interface Driver<OptionsT = any, InstanceT = any> {
   name?: string;
+  flags?: DriverFlags;
   options?: OptionsT;
   getInstance?: () => InstanceT;
   hasItem: (key: string, opts: TransactionOptions) => MaybePromise<boolean>;


### PR DESCRIPTION
resolves #549

Adds `flags` to the `Driver` type which can be used in future to determine if a driver supports a particular feature or requires some behaviour.

maybe something like this @pi0 ? and in a separate PR, add the flags to the fs drivers
