### PR TITLE
feat: strongly type extended drivers

### DIFF
--- a/src/drivers/capacitor-preferences.ts
+++ b/src/drivers/capacitor-preferences.ts
@@ -8,46 +8,44 @@ export interface CapacitorPreferencesOptions {
   base?: string;
 }
 
-export default defineDriver<CapacitorPreferencesOptions, typeof Preferences>(
-  (opts) => {
-    const base = normalizeKey(opts?.base || "");
-    const resolveKey = (key: string) => joinKeys(base, key);
+export default defineDriver((opts: CapacitorPreferencesOptions) => {
+  const base = normalizeKey(opts?.base || "");
+  const resolveKey = (key: string) => joinKeys(base, key);
 
-    return {
-      name: DRIVER_NAME,
-      options: opts,
-      getInstance: () => Preferences,
-      hasItem(key) {
-        return Preferences.keys().then((r) => r.keys.includes(resolveKey(key)));
-      },
-      getItem(key) {
-        return Preferences.get({ key: resolveKey(key) }).then((r) => r.value);
-      },
-      getItemRaw(key) {
-        return Preferences.get({ key: resolveKey(key) }).then((r) => r.value);
-      },
-      setItem(key, value) {
-        return Preferences.set({ key: resolveKey(key), value });
-      },
-      setItemRaw(key, value) {
-        return Preferences.set({ key: resolveKey(key), value });
-      },
-      removeItem(key) {
-        return Preferences.remove({ key: resolveKey(key) });
-      },
-      async getKeys() {
-        const { keys } = await Preferences.keys();
-        return keys.map((key) => key.slice(base.length));
-      },
-      async clear(prefix) {
-        const { keys } = await Preferences.keys();
-        const _prefix = resolveKey(prefix || "");
-        await Promise.all(
-          keys
-            .filter((key) => key.startsWith(_prefix))
-            .map((key) => Preferences.remove({ key }))
-        );
-      },
-    };
-  }
-);
+  return {
+    name: DRIVER_NAME,
+    options: opts,
+    getInstance: () => Preferences,
+    hasItem(key) {
+      return Preferences.keys().then((r) => r.keys.includes(resolveKey(key)));
+    },
+    getItem(key) {
+      return Preferences.get({ key: resolveKey(key) }).then((r) => r.value);
+    },
+    getItemRaw(key) {
+      return Preferences.get({ key: resolveKey(key) }).then((r) => r.value);
+    },
+    setItem(key, value) {
+      return Preferences.set({ key: resolveKey(key), value });
+    },
+    setItemRaw(key, value) {
+      return Preferences.set({ key: resolveKey(key), value });
+    },
+    removeItem(key) {
+      return Preferences.remove({ key: resolveKey(key) });
+    },
+    async getKeys() {
+      const { keys } = await Preferences.keys();
+      return keys.map((key) => key.slice(base.length));
+    },
+    async clear(prefix) {
+      const { keys } = await Preferences.keys();
+      const _prefix = resolveKey(prefix || "");
+      await Promise.all(
+        keys
+          .filter((key) => key.startsWith(_prefix))
+          .map((key) => Preferences.remove({ key }))
+      );
+    },
+  };
+});

--- a/src/drivers/cloudflare-kv-http.ts
+++ b/src/drivers/cloudflare-kv-http.ts
@@ -86,7 +86,7 @@ type CloudflareAuthorizationHeaders =
 
 const DRIVER_NAME = "cloudflare-kv-http";
 
-export default defineDriver<KVHTTPOptions>((opts) => {
+export default defineDriver((opts: KVHTTPOptions) => {
   if (!opts.accountId) {
     throw createRequiredError(DRIVER_NAME, "accountId");
   }

--- a/src/drivers/deno-kv-node.ts
+++ b/src/drivers/deno-kv-node.ts
@@ -12,18 +12,16 @@ export interface DenoKvNodeOptions {
 
 const DRIVER_NAME = "deno-kv-node";
 
-export default defineDriver<DenoKvNodeOptions, Kv | Promise<Kv>>(
-  (opts: DenoKvNodeOptions = {}) => {
-    const baseDriver = denoKV({
-      ...opts,
-      openKv: () => openKv(opts.path, opts.openKvOptions),
-    });
-    return {
-      ...baseDriver,
-      getInstance() {
-        return baseDriver.getInstance!() as Promise<Kv>;
-      },
-      name: DRIVER_NAME,
-    };
-  }
-);
+export default defineDriver((opts: DenoKvNodeOptions = {}) => {
+  const baseDriver = denoKV({
+    ...opts,
+    openKv: () => openKv(opts.path, opts.openKvOptions),
+  });
+  return {
+    ...baseDriver,
+    getInstance() {
+      return baseDriver.getInstance!() as Promise<Kv>;
+    },
+    name: DRIVER_NAME,
+  };
+});

--- a/src/drivers/deno-kv.ts
+++ b/src/drivers/deno-kv.ts
@@ -12,100 +12,96 @@ export interface DenoKvOptions {
 
 const DRIVER_NAME = "deno-kv";
 
-export default defineDriver<DenoKvOptions, Promise<Deno.Kv | Kv>>(
-  (opts: DenoKvOptions = {}) => {
-    const basePrefix: KvKey = opts.base
-      ? normalizeKey(opts.base).split(":")
-      : [];
+export default defineDriver((opts: DenoKvOptions = {}) => {
+  const basePrefix: KvKey = opts.base ? normalizeKey(opts.base).split(":") : [];
 
-    const r = (key: string = ""): KvKey =>
-      [...basePrefix, ...key.split(":")].filter(Boolean);
+  const r = (key: string = ""): KvKey =>
+    [...basePrefix, ...key.split(":")].filter(Boolean);
 
-    let _kv: Promise<Kv | Deno.Kv> | undefined;
-    const getKv = () => {
-      if (_kv) {
-        return _kv;
-      }
-      if (opts.openKv) {
-        _kv = opts.openKv();
-      } else {
-        if (!globalThis.Deno) {
-          throw createError(
-            DRIVER_NAME,
-            "Missing global `Deno`. Are you running in Deno? (hint: use `deno-kv-node` driver for Node.js)"
-          );
-        }
-        if (!Deno.openKv) {
-          throw createError(
-            DRIVER_NAME,
-            "Missing `Deno.openKv`. Are you running Deno with --unstable-kv?"
-          );
-        }
-        _kv = Deno.openKv(opts.path);
-      }
+  let _kv: Promise<Kv | Deno.Kv> | undefined;
+  const getKv = () => {
+    if (_kv) {
       return _kv;
-    };
+    }
+    if (opts.openKv) {
+      _kv = opts.openKv();
+    } else {
+      if (!globalThis.Deno) {
+        throw createError(
+          DRIVER_NAME,
+          "Missing global `Deno`. Are you running in Deno? (hint: use `deno-kv-node` driver for Node.js)"
+        );
+      }
+      if (!Deno.openKv) {
+        throw createError(
+          DRIVER_NAME,
+          "Missing `Deno.openKv`. Are you running Deno with --unstable-kv?"
+        );
+      }
+      _kv = Deno.openKv(opts.path);
+    }
+    return _kv;
+  };
 
-    return {
-      name: DRIVER_NAME,
-      getInstance() {
-        return getKv();
-      },
-      async hasItem(key) {
-        const kv = await getKv();
-        const value = await kv.get(r(key));
-        return !!value.value;
-      },
-      async getItem(key) {
-        const kv = await getKv();
-        const value = await kv.get(r(key));
-        return value.value;
-      },
-      async getItemRaw(key) {
-        const kv = await getKv();
-        const value = await kv.get(r(key));
-        return value.value;
-      },
-      async setItem(key, value) {
-        const kv = await getKv();
-        await kv.set(r(key), value);
-      },
-      async setItemRaw(key, value) {
-        const kv = await getKv();
-        await kv.set(r(key), value);
-      },
-      async removeItem(key) {
-        const kv = await getKv();
-        await kv.delete(r(key));
-      },
-      async getKeys(base) {
-        const kv = await getKv();
-        const keys: string[] = [];
-        for await (const entry of kv.list({ prefix: r(base) })) {
-          keys.push(
-            (basePrefix.length > 0
-              ? entry.key.slice(basePrefix.length)
-              : entry.key
-            ).join(":")
-          );
-        }
-        return keys;
-      },
-      async clear(base) {
-        const kv = await getKv();
-        const batch = kv.atomic();
-        for await (const entry of kv.list({ prefix: r(base) })) {
-          batch.delete(entry.key as KvKey);
-        }
-        await batch.commit();
-      },
-      async dispose() {
-        if (_kv) {
-          const kv = await _kv;
-          await kv.close();
-          _kv = undefined;
-        }
-      },
-    };
-  }
-);
+  return {
+    name: DRIVER_NAME,
+    getInstance() {
+      return getKv();
+    },
+    async hasItem(key) {
+      const kv = await getKv();
+      const value = await kv.get(r(key));
+      return !!value.value;
+    },
+    async getItem(key) {
+      const kv = await getKv();
+      const value = await kv.get(r(key));
+      return value.value;
+    },
+    async getItemRaw(key) {
+      const kv = await getKv();
+      const value = await kv.get(r(key));
+      return value.value;
+    },
+    async setItem(key, value) {
+      const kv = await getKv();
+      await kv.set(r(key), value);
+    },
+    async setItemRaw(key, value) {
+      const kv = await getKv();
+      await kv.set(r(key), value);
+    },
+    async removeItem(key) {
+      const kv = await getKv();
+      await kv.delete(r(key));
+    },
+    async getKeys(base) {
+      const kv = await getKv();
+      const keys: string[] = [];
+      for await (const entry of kv.list({ prefix: r(base) })) {
+        keys.push(
+          (basePrefix.length > 0
+            ? entry.key.slice(basePrefix.length)
+            : entry.key
+          ).join(":")
+        );
+      }
+      return keys;
+    },
+    async clear(base) {
+      const kv = await getKv();
+      const batch = kv.atomic();
+      for await (const entry of kv.list({ prefix: r(base) })) {
+        batch.delete(entry.key as KvKey);
+      }
+      await batch.commit();
+    },
+    async dispose() {
+      if (_kv) {
+        const kv = await _kv;
+        await kv.close();
+        _kv = undefined;
+      }
+    },
+  };
+});

--- a/src/drivers/github.ts
+++ b/src/drivers/github.ts
@@ -55,7 +55,7 @@ const defaultOptions: GithubOptions = {
 
 const DRIVER_NAME = "github";
 
-export default defineDriver<GithubOptions>((_opts) => {
+export default defineDriver((_opts: GithubOptions) => {
   const opts: GithubOptions = { ...defaultOptions, ..._opts };
   const rawUrl = joinURL(opts.cdnURL!, opts.repo, opts.branch!, opts.dir!);
 

--- a/src/drivers/memory.ts
+++ b/src/drivers/memory.ts
@@ -2,7 +2,7 @@ import { defineDriver } from "./utils";
 
 const DRIVER_NAME = "memory";
 
-export default defineDriver<void, Map<string, any>>(() => {
+export default defineDriver(() => {
   const data = new Map<string, any>();
 
   return {

--- a/src/drivers/null.ts
+++ b/src/drivers/null.ts
@@ -2,7 +2,7 @@ import { defineDriver } from "./utils";
 
 const DRIVER_NAME = "null";
 
-export default defineDriver<void>(() => {
+export default defineDriver(() => {
   return {
     name: DRIVER_NAME,
     hasItem() {

--- a/src/drivers/session-storage.ts
+++ b/src/drivers/session-storage.ts
@@ -7,10 +7,10 @@ const DRIVER_NAME = "session-storage";
 
 export default defineDriver((opts: SessionStorageOptions = {}) => {
   return {
-    name: DRIVER_NAME,
     ...localstorage({
       windowKey: "sessionStorage",
       ...opts,
     }),
+    name: DRIVER_NAME,
   };
 });

--- a/src/drivers/uploadthing.ts
+++ b/src/drivers/uploadthing.ts
@@ -17,7 +17,7 @@ export interface UploadThingOptions extends UTApiOptions {
 
 const DRIVER_NAME = "uploadthing";
 
-export default defineDriver<UploadThingOptions, UTApi>((opts = {}) => {
+export default defineDriver((opts: UploadThingOptions = {}) => {
   let client: UTApi;
 
   const base = opts.base ? normalizeKey(opts.base) : "";

--- a/src/drivers/upstash.ts
+++ b/src/drivers/upstash.ts
@@ -15,59 +15,56 @@ export interface UpstashOptions extends Partial<RedisConfigNodejs> {
 
 const DRIVER_NAME = "upstash";
 
-export default defineDriver<UpstashOptions, Redis>(
-  (options: UpstashOptions = {}) => {
-    const base = normalizeKey(options?.base);
-    const r = (...keys: string[]) => joinKeys(base, ...keys);
+export default defineDriver((options: UpstashOptions = {}) => {
+  const base = normalizeKey(options?.base);
+  const r = (...keys: string[]) => joinKeys(base, ...keys);
 
-    let redisClient: Redis;
-    const getClient = () => {
-      if (redisClient) {
-        return redisClient;
-      }
-      const url =
-        options.url || globalThis.process?.env?.UPSTASH_REDIS_REST_URL;
-      const token =
-        options.token || globalThis.process?.env?.UPSTASH_REDIS_REST_TOKEN;
-      redisClient = new Redis({ url, token, ...options });
+  let redisClient: Redis;
+  const getClient = () => {
+    if (redisClient) {
       return redisClient;
-    };
-    return {
-      name: DRIVER_NAME,
-      getInstance: getClient,
-      hasItem(key) {
-        return getClient().exists(r(key)).then(Boolean);
-      },
-      getItem(key) {
-        return getClient().get(r(key));
-      },
-      setItem(key, value, tOptions) {
-        const ttl = tOptions?.ttl || options.ttl;
-        return getClient()
-          .set(r(key), value, ttl ? { ex: ttl } : undefined)
-          .then(() => {});
-      },
-      removeItem(key) {
-        return getClient()
-          .del(r(key))
-          .then(() => {});
-      },
-      getKeys(_base) {
-        return getClient()
-          .keys(r(_base, "*"))
-          .then((keys) =>
-            base ? keys.map((key) => key.slice(base.length + 1)) : keys
-          );
-      },
-      async clear(base) {
-        const keys = await getClient().keys(r(base, "*"));
-        if (keys.length === 0) {
-          return;
-        }
-        return getClient()
-          .del(...keys)
-          .then(() => {});
-      },
-    };
-  }
-);
+    }
+    const url = options.url || globalThis.process?.env?.UPSTASH_REDIS_REST_URL;
+    const token =
+      options.token || globalThis.process?.env?.UPSTASH_REDIS_REST_TOKEN;
+    redisClient = new Redis({ url, token, ...options });
+    return redisClient;
+  };
+  return {
+    name: DRIVER_NAME,
+    getInstance: getClient,
+    hasItem(key) {
+      return getClient().exists(r(key)).then(Boolean);
+    },
+    getItem(key) {
+      return getClient().get(r(key));
+    },
+    setItem(key, value, tOptions) {
+      const ttl = tOptions?.ttl || options.ttl;
+      return getClient()
+        .set(r(key), value, ttl ? { ex: ttl } : undefined)
+        .then(() => {});
+    },
+    removeItem(key) {
+      return getClient()
+        .del(r(key))
+        .then(() => {});
+    },
+    getKeys(_base) {
+      return getClient()
+        .keys(r(_base, "*"))
+        .then((keys) =>
+          base ? keys.map((key) => key.slice(base.length + 1)) : keys
+        );
+    },
+    async clear(base) {
+      const keys = await getClient().keys(r(base, "*"));
+      if (keys.length === 0) {
+        return;
+      }
+      return getClient()
+        .del(...keys)
+        .then(() => {});
+    },
+  };
+});

--- a/src/drivers/utils/index.ts
+++ b/src/drivers/utils/index.ts
@@ -1,13 +1,15 @@
 import type { Driver } from "../..";
 
-type DriverFactory<OptionsT, InstanceT> = (
-  opts: OptionsT
-) => Driver<OptionsT, InstanceT>;
 interface ErrorOptions {}
 
-export function defineDriver<OptionsT = any, InstanceT = never>(
-  factory: DriverFactory<OptionsT, InstanceT>
-): DriverFactory<OptionsT, InstanceT> {
+export function defineDriver<
+  TOptions,
+  TInstance,
+  TDriver extends Driver<TOptions, TInstance>,
+  TArgs extends unknown[],
+>(
+  factory: (...args: TArgs) => TDriver
+): (...args: TArgs) => TDriver & Driver<TOptions, TInstance> {
   return factory;
 }
 

--- a/src/drivers/vercel-blob.ts
+++ b/src/drivers/vercel-blob.ts
@@ -27,7 +27,7 @@ export interface VercelBlobOptions {
 
 const DRIVER_NAME = "vercel-blob";
 
-export default defineDriver<VercelBlobOptions>((opts) => {
+export default defineDriver((opts: VercelBlobOptions) => {
   const optsBase = normalizeKey(opts?.base);
 
   const r = (...keys: string[]) =>

--- a/src/drivers/vercel-kv.ts
+++ b/src/drivers/vercel-kv.ts
@@ -23,7 +23,7 @@ export interface VercelKVOptions extends Partial<RedisConfigNodejs> {
 
 const DRIVER_NAME = "vercel-kv";
 
-export default defineDriver<VercelKVOptions, VercelKV>((opts) => {
+export default defineDriver((opts: VercelKVOptions) => {
   const base = normalizeKey(opts?.base);
   const r = (...keys: string[]) => joinKeys(base, ...keys);
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,7 +26,7 @@ export interface Driver<OptionsT = any, InstanceT = any> {
   name?: string;
   options?: OptionsT;
   getInstance?: () => InstanceT;
-  hasItem: (key: string, opts: TransactionOptions) => MaybePromise<boolean>;
+  hasItem: (key: string, opts?: TransactionOptions) => MaybePromise<boolean>;
   getItem: (
     key: string,
     opts?: TransactionOptions
@@ -37,11 +37,14 @@ export interface Driver<OptionsT = any, InstanceT = any> {
     commonOptions?: TransactionOptions
   ) => MaybePromise<{ key: string; value: StorageValue }[]>;
   /** @experimental */
-  getItemRaw?: (key: string, opts: TransactionOptions) => MaybePromise<unknown>;
+  getItemRaw?: (
+    key: string,
+    opts?: TransactionOptions
+  ) => MaybePromise<unknown>;
   setItem?: (
     key: string,
     value: string,
-    opts: TransactionOptions
+    opts?: TransactionOptions
   ) => MaybePromise<void>;
   /** @experimental */
   setItems?: (
@@ -52,15 +55,15 @@ export interface Driver<OptionsT = any, InstanceT = any> {
   setItemRaw?: (
     key: string,
     value: any,
-    opts: TransactionOptions
+    opts?: TransactionOptions
   ) => MaybePromise<void>;
   removeItem?: (key: string, opts: TransactionOptions) => MaybePromise<void>;
   getMeta?: (
     key: string,
-    opts: TransactionOptions
+    opts?: TransactionOptions
   ) => MaybePromise<StorageMeta | null>;
-  getKeys: (base: string, opts: GetKeysOptions) => MaybePromise<string[]>;
-  clear?: (base: string, opts: TransactionOptions) => MaybePromise<void>;
+  getKeys: (base: string, opts?: GetKeysOptions) => MaybePromise<string[]>;
+  clear?: (base: string, opts?: TransactionOptions) => MaybePromise<void>;
   dispose?: () => MaybePromise<void>;
   watch?: (callback: WatchCallback) => MaybePromise<Unwatch>;
 }

--- a/test/drivers/utils.ts
+++ b/test/drivers/utils.ts
@@ -6,18 +6,18 @@ import {
   restoreSnapshot,
 } from "../../src";
 
-export interface TestContext {
+export interface TestContext<T extends Driver> {
   storage: Storage;
-  driver: Driver;
+  driver: T;
 }
 
-export interface TestOptions {
-  driver: Driver | (() => Driver);
-  additionalTests?: (ctx: TestContext) => void;
+export interface TestOptions<T extends Driver> {
+  driver: T | (() => T);
+  additionalTests?: (ctx: TestContext<T>) => void;
 }
 
-export function testDriver(opts: TestOptions) {
-  const ctx = {} as TestContext;
+export function testDriver<T extends Driver>(opts: TestOptions<T>) {
+  const ctx = {} as TestContext<T>;
 
   beforeAll(() => {
     ctx.driver =

--- a/test/storage.test.ts
+++ b/test/storage.test.ts
@@ -4,6 +4,7 @@ import {
   snapshot,
   restoreSnapshot,
   prefixStorage,
+  type Driver,
 } from "../src";
 import memory from "../src/drivers/memory";
 
@@ -184,7 +185,7 @@ describe("Regression", () => {
     const setItem = vi.fn();
     const setItems = vi.fn();
 
-    const driver = memory();
+    const driver = memory() as Driver<unknown, unknown>;
     const storage = createStorage({
       driver: {
         ...driver,


### PR DESCRIPTION

Currently, a driver can define its own method signatures but they will be lost thanks to `DriverFactory` returning a `Driver` rather than the original type.

This means things like the netlify driver never actually exposed their extended types (e.g. special options in `getKeys`).

```ts
import driver from "./netlify-blobs";

const instance = driver();

// BEFORE

instance.getKeys;
//`        ^? getKeys(base?: string, opts: GetKeysOptions)

// AFTER

instance.getKeys;
//         ^? getKeys(base?: string, tops?: GetKeysOptions & Omit<ListOptions, "prefix" | "paginate">)
```

With these changes, a driver can implement `Driver` but add its own types on top which are then exposed.
