### PR TITLE
feat: pass lru options through

### DIFF
--- a/src/drivers/lru-cache.ts
+++ b/src/drivers/lru-cache.ts
@@ -1,5 +1,6 @@
 import { defineDriver } from "./utils";
 import { LRUCache } from "lru-cache";
+import { type TransactionOptions, type StorageValue } from "../types";
 
 type LRUCacheOptions = LRUCache.OptionsBase<string, any, any> &
   Partial<LRUCache.OptionsMaxLimit<string, any, any>> &
@@ -9,6 +10,13 @@ type LRUCacheOptions = LRUCache.OptionsBase<string, any, any> &
 export interface LRUDriverOptions extends LRUCacheOptions {}
 
 const DRIVER_NAME = "lru-cache";
+
+export type HasItemOptions = LRUCache.HasOptions<string, any, any> &
+  TransactionOptions;
+export type GetItemOptions = LRUCache.GetOptions<string, any, any> &
+  TransactionOptions;
+export type SetItemOptions = LRUCache.SetOptions<string, any, any> &
+  TransactionOptions;
 
 export default defineDriver((opts: LRUDriverOptions = {}) => {
   const cache = new LRUCache({
@@ -26,20 +34,23 @@ export default defineDriver((opts: LRUDriverOptions = {}) => {
     name: DRIVER_NAME,
     options: opts,
     getInstance: () => cache,
-    hasItem(key) {
-      return cache.has(key);
+    hasItem(key, opts?: HasItemOptions) {
+      return cache.has(key, opts);
     },
-    getItem(key) {
-      return cache.get(key) ?? null;
+    // Note: its important we specify the return types here, since
+    // otherwise we will end up adding an overload of `getItem` which
+    // returns `any`
+    getItem(key, opts?: GetItemOptions): StorageValue {
+      return cache.get(key, opts) ?? null;
     },
-    getItemRaw(key) {
-      return cache.get(key) ?? null;
+    getItemRaw(key, opts?: GetItemOptions): StorageValue {
+      return cache.get(key, opts) ?? null;
     },
-    setItem(key, value) {
-      cache.set(key, value);
+    setItem(key, value, opts?: SetItemOptions) {
+      cache.set(key, value, opts);
     },
-    setItemRaw(key, value) {
-      cache.set(key, value);
+    setItemRaw(key, value, opts?: SetItemOptions) {
+      cache.set(key, value, opts);
     },
     removeItem(key) {
       cache.delete(key);

--- a/test/drivers/lru-cache.test.ts
+++ b/test/drivers/lru-cache.test.ts
@@ -1,6 +1,7 @@
-import { it, describe, expect } from "vitest";
+import { it, describe, expect, vi, afterEach } from "vitest";
 import driver from "../../src/drivers/lru-cache";
 import { testDriver } from "./utils";
+import { LRUCache } from "lru-cache";
 
 describe("drivers: lru-cache", () => {
   testDriver({
@@ -9,6 +10,10 @@ describe("drivers: lru-cache", () => {
 });
 
 describe("drivers: lru-cache with size", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   testDriver({
     driver: driver({
       maxEntrySize: 50,
@@ -23,6 +28,39 @@ describe("drivers: lru-cache with size", () => {
 
         await ctx.storage.setItemRaw("bigBuff", Buffer.alloc(100));
         expect(await ctx.storage.getItemRaw("bigBuff")).toBe(null);
+      });
+
+      it("should pass `setItem` options through", async () => {
+        const spy = vi.spyOn(LRUCache.prototype, "set");
+        await ctx.storage.setItem("foo", "test_data", {
+          noUpdateTTL: true,
+        });
+
+        expect(spy).toHaveBeenCalledWith("foo", "test_data", {
+          noUpdateTTL: true,
+        });
+      });
+
+      it("should pass `setItemRaw` options through", async () => {
+        const spy = vi.spyOn(LRUCache.prototype, "set");
+        await ctx.storage.setItemRaw("foo", "test_data", {
+          noUpdateTTL: true,
+        });
+
+        expect(spy).toHaveBeenCalledWith("foo", "test_data", {
+          noUpdateTTL: true,
+        });
+      });
+
+      it("should pass `hasItem` options through", async () => {
+        const spy = vi.spyOn(LRUCache.prototype, "has");
+        await ctx.storage.hasItem("foo", {
+          updateAgeOnHas: true,
+        });
+
+        expect(spy).toHaveBeenCalledWith("foo", {
+          updateAgeOnHas: true,
+        });
       });
     },
   });


### PR DESCRIPTION
Fixes #466

This changes the `lru-cache` such that the following methods accept LRU options (and pass them through to the underlying methods):

- `setItem`
- `setItemRaw`
- `hasItem`
