### PR TITLE
fix(prefixStorage): wrap shorthand aliases

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,11 +3,16 @@ import type { Storage, StorageValue } from "./types";
 type StorageKeys = Array<keyof Storage>;
 
 const storageKeyProperties: StorageKeys = [
+  "has",
   "hasItem",
+  "get",
   "getItem",
   "getItemRaw",
+  "set",
   "setItem",
   "setItemRaw",
+  "del",
+  "remove",
   "removeItem",
   "getMeta",
   "setMeta",

--- a/test/storage.test.ts
+++ b/test/storage.test.ts
@@ -203,4 +203,23 @@ describe("Regression", () => {
     expect(setItem).toHaveBeenCalledTimes(0);
     expect(setItems).toHaveBeenCalledTimes(1);
   });
+
+  it("prefixed storage supports aliases", async () => {
+    const storage = createStorage();
+    const pStorage = prefixStorage(storage, "foo");
+
+    await pStorage.set("x", "foo");
+    await pStorage.set("y", "bar");
+
+    expect(await pStorage.get("x")).toBe("foo");
+    expect(await pStorage.get("x")).toBe("foo");
+    expect(await pStorage.has("x")).toBe(true);
+    expect(await pStorage.get("y")).toBe("bar");
+
+    await pStorage.del("x");
+    expect(await pStorage.has("x")).toBe(false);
+
+    await pStorage.remove("y");
+    expect(await pStorage.has("y")).toBe(false);
+  });
 });


### PR DESCRIPTION
When creating a prefixed storage, the `get`, `set`, `has`, `del`, `remove` aliases don't work as intended (they do not get the defined prefixe) as they are not defined in the `storageKeyProperties` in https://github.com/unjs/unstorage/blob/main/src/utils.ts

- Added `get`, `set`, `has`, `del`, `remove` in `storageKeyProperties`
- Added regression tests 

Related with breaking changes : https://github.com/unjs/unstorage/pull/455