### PR TITLE
perf: skip `maxDepth` filtering if natively supported

### DIFF
--- a/src/drivers/fs-lite.ts
+++ b/src/drivers/fs-lite.ts
@@ -40,6 +40,9 @@ export default defineDriver((opts: FSStorageOptions = {}) => {
   return {
     name: DRIVER_NAME,
     options: opts,
+    flags: {
+      maxDepth: true,
+    },
     hasItem(key) {
       return existsSync(r(key));
     },

--- a/src/drivers/fs.ts
+++ b/src/drivers/fs.ts
@@ -59,6 +59,9 @@ export default defineDriver((opts: FSStorageOptions = {}) => {
   return {
     name: DRIVER_NAME,
     options: opts,
+    flags: {
+      maxDepth: true,
+    },
     hasItem(key) {
       return existsSync(r(key));
     },

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -348,7 +348,11 @@ export function createStorage<T extends StorageValue>(
       const mounts = getMounts(base, true);
       let maskedMounts: string[] = [];
       const allKeys = [];
+      let allMountsSupportMaxDepth = true;
       for (const mount of mounts) {
+        if (!mount.driver.flags?.maxDepth) {
+          allMountsSupportMaxDepth = false;
+        }
         const rawKeys = await asyncCall(
           mount.driver.getKeys,
           mount.relativeBase,
@@ -368,10 +372,11 @@ export function createStorage<T extends StorageValue>(
           ...maskedMounts.filter((p) => !p.startsWith(mount.mountpoint)),
         ];
       }
+      const shouldFilterByDepth =
+        opts.maxDepth !== undefined && !allMountsSupportMaxDepth;
       return allKeys.filter(
         (key) =>
-          (opts.maxDepth === undefined ||
-            filterKeyByDepth(key, opts.maxDepth)) &&
+          (!shouldFilterByDepth || filterKeyByDepth(key, opts.maxDepth)) &&
           filterKeyByBase(key, base)
       );
     },


### PR DESCRIPTION
Skips `maxDepth` filtering if _all_ drivers in the current storage instance natively support it (via the `maxDepth` flag).

Also enables the `maxDepth` flag for `fs` and `fs-lite` drivers.

Depends on #551 