### PR TITLE
feat(azure-storage-blob): add raw support

### DIFF
--- a/docs/2.drivers/azure.md
+++ b/docs/2.drivers/azure.md
@@ -193,7 +193,11 @@ The driver supports the following authentication methods:
 - `containerName`: The name of the blob container to use. Defaults to `unstorage`.
 - `accountKey`: The account key to use for authentication. This is only required if you are using `AzureNamedKeyCredential`.
 - `sasKey`: The SAS token to use for authentication. This is only required if you are using `AzureSASCredential`.
+- `sasUrl`: The SAS URL of the storage account. This is an alternative to providing `accountName` and `sasKey` separately. The URL can be either:
+  - A storage account URL: `https://<account>.blob.core.windows.net?<sas-token>`
+  - A container URL: `https://<account>.blob.core.windows.net/<container>?<sas-token>` you must specify the `containerName` option
 - `connectionString`: The storage accounts' connection string. `accountKey` and `sasKey` take precedence.
+- `endpointSuffix`: Storage account endpoint suffix. Needs to be changed for Microsoft Azure operated by 21Vianet, Azure Government or Azurite. Defaults to `.blob.core.windows.net`.
 
 ## Azure Table Storage
 

--- a/src/drivers/azure-storage-blob.ts
+++ b/src/drivers/azure-storage-blob.ts
@@ -54,7 +54,7 @@ export default defineDriver((opts: AzureStorageBlobOptions) => {
     if (containerClient) {
       return containerClient;
     }
-    if (!(opts.connectionString || opts.sasUrl) && !opts.accountName) {
+    if (!opts.connectionString && !opts.sasUrl && !opts.accountName) {
       throw createError(DRIVER_NAME, "missing accountName");
     }
     let serviceClient: BlobServiceClient;
@@ -155,14 +155,9 @@ export default defineDriver((opts: AzureStorageBlobOptions) => {
         .upload(value, Buffer.byteLength(value));
     },
     async removeItem(key) {
-      const exists = await getContainerClient()
+      await getContainerClient()
         .getBlockBlobClient(key)
-        .exists();
-      if (exists) {
-        await getContainerClient()
-          .getBlockBlobClient(key)
-          .delete({ deleteSnapshots: "include" });
-      }
+        .deleteIfExists({ deleteSnapshots: "include" });
     },
     async getKeys() {
       const iterator = getContainerClient()

--- a/src/drivers/azure-storage-blob.ts
+++ b/src/drivers/azure-storage-blob.ts
@@ -100,7 +100,27 @@ export default defineDriver((opts: AzureStorageBlobOptions) => {
         return null;
       }
     },
+    async getItemRaw(key) {
+      try {
+        const blob = await getContainerClient()
+          .getBlockBlobClient(key)
+          .download();
+        if (isBrowser) {
+          return blob.blobBody ? await blobToString(await blob.blobBody) : null;
+        }
+        return blob.readableStreamBody
+          ? await streamToBuffer(blob.readableStreamBody)
+          : null;
+      } catch {
+        return null;
+      }
+    },
     async setItem(key, value) {
+      await getContainerClient()
+        .getBlockBlobClient(key)
+        .upload(value, Buffer.byteLength(value));
+    },
+    async setItemRaw(key, value) {
       await getContainerClient()
         .getBlockBlobClient(key)
         .upload(value, Buffer.byteLength(value));

--- a/src/drivers/azure-storage-blob.ts
+++ b/src/drivers/azure-storage-blob.ts
@@ -69,7 +69,11 @@ export default defineDriver((opts: AzureStorageBlobOptions) => {
         credential
       );
     } else if (opts.sasUrl) {
-      if (opts.containerName) {
+      if (
+        opts.containerName &&
+        opts.sasUrl.includes(`${opts.containerName}?`)
+      ) {
+        // Check if the sas url is a container url
         containerClient = new ContainerClient(`${opts.sasUrl}`);
         return containerClient;
       }

--- a/src/drivers/azure-storage-blob.ts
+++ b/src/drivers/azure-storage-blob.ts
@@ -106,7 +106,14 @@ export default defineDriver((opts: AzureStorageBlobOptions) => {
         .upload(value, Buffer.byteLength(value));
     },
     async removeItem(key) {
-      await getContainerClient().getBlockBlobClient(key).delete();
+      const exists = await getContainerClient()
+        .getBlockBlobClient(key)
+        .exists();
+      if (exists) {
+        await getContainerClient()
+          .getBlockBlobClient(key)
+          .delete({ deleteSnapshots: "include" });
+      }
     },
     async getKeys() {
       const iterator = getContainerClient()

--- a/test/drivers/azure-storage-blob.test.ts
+++ b/test/drivers/azure-storage-blob.test.ts
@@ -29,7 +29,7 @@ describe.skip("drivers: azure-storage-blob", () => {
       connectionString: "UseDevelopmentStorage=true;",
       accountName: "devstoreaccount1",
     }),
-    additionalTests(ctx) {
+    additionalTests() {
       test("no empty account name", async () => {
         const invalidStorage = createStorage({
           driver: driver({
@@ -91,14 +91,6 @@ describe.skip("drivers: azure-storage-blob", () => {
           }),
         });
         await storage.getKeys();
-      });
-      test("properly encodes raw items", async () => {
-        const file = await readFile("./test/test.png");
-
-        await ctx.storage.setItemRaw("1.png", file);
-        const storedFileNode = await ctx.storage.getItemRaw("1.png");
-
-        expect(storedFileNode).toStrictEqual(file);
       });
     },
   });

--- a/test/drivers/azure-storage-blob.test.ts
+++ b/test/drivers/azure-storage-blob.test.ts
@@ -1,4 +1,5 @@
-import { describe, beforeAll, afterAll } from "vitest";
+import { describe, expect, beforeAll, afterAll, test } from "vitest";
+import { readFile } from "../../src/drivers/utils/node-fs";
 import driver from "../../src/drivers/azure-storage-blob";
 import { testDriver } from "./utils";
 import { BlobServiceClient } from "@azure/storage-blob";
@@ -22,5 +23,15 @@ describe.skip("drivers: azure-storage-blob", () => {
       connectionString: "UseDevelopmentStorage=true",
       accountName: "local",
     }),
+    additionalTests(ctx) {
+      test("properly encodes raw items", async () => {
+        const file = await readFile("./test/test.png");
+
+        await ctx.storage.setItemRaw("1.png", file);
+        const storedFileNode = await ctx.storage.getItemRaw("1.png");
+
+        expect(storedFileNode).toStrictEqual(file);
+      });
+    },
   });
 });

--- a/test/drivers/azure-storage-blob.test.ts
+++ b/test/drivers/azure-storage-blob.test.ts
@@ -2,28 +2,95 @@ import { describe, expect, beforeAll, afterAll, test } from "vitest";
 import { readFile } from "../../src/drivers/utils/node-fs";
 import driver from "../../src/drivers/azure-storage-blob";
 import { testDriver } from "./utils";
-import { BlobServiceClient } from "@azure/storage-blob";
+import { AccountSASPermissions, BlobServiceClient } from "@azure/storage-blob";
 import { ChildProcess, exec } from "node:child_process";
+import { createStorage } from "../../src";
 
 describe.skip("drivers: azure-storage-blob", () => {
   let azuriteProcess: ChildProcess;
+  let sasUrl: string;
   beforeAll(async () => {
-    azuriteProcess = exec("npx azurite-blob --silent");
+    azuriteProcess = exec("pnpm exec azurite-blob --silent");
     const client = BlobServiceClient.fromConnectionString(
-      "UseDevelopmentStorage=true"
+      "UseDevelopmentStorage=true;"
     );
     const containerClient = client.getContainerClient("unstorage");
     await containerClient.createIfNotExists();
+    sasUrl = client.generateAccountSasUrl(
+      new Date(Date.now() + 1000 * 60),
+      AccountSASPermissions.from({ read: true, list: true, write: true })
+    );
   });
   afterAll(() => {
     azuriteProcess.kill(9);
   });
   testDriver({
     driver: driver({
-      connectionString: "UseDevelopmentStorage=true",
-      accountName: "local",
+      connectionString: "UseDevelopmentStorage=true;",
+      accountName: "devstoreaccount1",
     }),
     additionalTests(ctx) {
+      test("no empty account name", async () => {
+        const invalidStorage = createStorage({
+          driver: driver({
+            accountKey: "UseDevelopmentStorage=true",
+          } as any),
+        });
+        await expect(
+          async () => await invalidStorage.hasItem("test")
+        ).rejects.toThrowError("missing accountName");
+      });
+      test("sas key", async ({ skip }) => {
+        if (
+          !process.env.AZURE_STORAGE_BLOB_SAS_KEY ||
+          !process.env.AZURE_STORAGE_BLOB_ACCOUNT_NAME
+        ) {
+          skip();
+        }
+        const storage = createStorage({
+          driver: driver({
+            sasKey: process.env.AZURE_STORAGE_BLOB_SAS_KEY,
+            accountName: process.env.AZURE_STORAGE_BLOB_ACCOUNT_NAME,
+            containerName: "unstorage",
+          }),
+        });
+        await storage.getKeys();
+      });
+      test("sas url", async () => {
+        const storage = createStorage({
+          driver: driver({
+            sasUrl,
+          }),
+        });
+        await storage.getKeys();
+      });
+      test("account key", async ({ skip }) => {
+        if (
+          !process.env.AZURE_STORAGE_BLOB_ACCOUNT_KEY ||
+          !process.env.AZURE_STORAGE_BLOB_ACCOUNT_NAME
+        ) {
+          skip();
+        }
+        const storage = createStorage({
+          driver: driver({
+            accountName: process.env.AZURE_STORAGE_BLOB_ACCOUNT_NAME,
+            accountKey: process.env.AZURE_STORAGE_BLOB_ACCOUNT_KEY,
+          }),
+        });
+        await storage.getKeys();
+      });
+      test("use DefaultAzureCredential", async ({ skip }) => {
+        if (!process.env.AZURE_STORAGE_BLOB_ACCOUNT_NAME) {
+          skip();
+        }
+        const storage = createStorage({
+          driver: driver({
+            accountName: process.env.AZURE_STORAGE_BLOB_ACCOUNT_NAME,
+            containerName: "unstorage",
+          }),
+        });
+        await storage.getKeys();
+      });
       test("properly encodes raw items", async () => {
         const file = await readFile("./test/test.png");
 

--- a/test/drivers/azure-storage-blob.test.ts
+++ b/test/drivers/azure-storage-blob.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, beforeAll, afterAll, test } from "vitest";
-import { readFile } from "../../src/drivers/utils/node-fs";
 import driver from "../../src/drivers/azure-storage-blob";
 import { testDriver } from "./utils";
 import { AccountSASPermissions, BlobServiceClient } from "@azure/storage-blob";

--- a/test/drivers/azure-storage-blob.test.ts
+++ b/test/drivers/azure-storage-blob.test.ts
@@ -60,6 +60,7 @@ describe.skip("drivers: azure-storage-blob", () => {
         const storage = createStorage({
           driver: driver({
             sasUrl,
+            containerName: "unstorage",
           }),
         });
         await storage.getKeys();


### PR DESCRIPTION
This PR adds raw item get/set support, similar to abandoned #442, but also adds test for that new procedures.

Also I have noticed that the current `removeItem` test fails, as `delete` operation with non-existent keys leads to an error. I _assume_ the intention is not to fail in such cases, so I have not changed the `removeItem` test, but added a check before attempting to delete the blob at the Azure Blob driver. 