### PR TITLE
feat(azure-drivers): add managed identity client ID support

### DIFF
--- a/src/drivers/azure-app-configuration.ts
+++ b/src/drivers/azure-app-configuration.ts
@@ -4,6 +4,12 @@ import { DefaultAzureCredential } from "@azure/identity";
 
 export interface AzureAppConfigurationOptions {
   /**
+   * Optional client ID for managed identity. Needed if using one or more user assigned managed identity to authenticate.
+   * @default null
+   */
+  managedIdentityClientId?: string;
+
+  /**
    * Optional prefix for keys. This can be used to isolate keys from different applications in the same Azure App Configuration instance. E.g. "app01" results in keys like "app01:foo" and "app01:bar".
    * @default null
    */
@@ -59,7 +65,11 @@ export default defineDriver((opts: AzureAppConfigurationOptions = {}) => {
     if (opts.connectionString) {
       client = new AppConfigurationClient(opts.connectionString);
     } else {
-      const credential = new DefaultAzureCredential();
+      const credential = opts.managedIdentityClientId
+        ? new DefaultAzureCredential({
+            managedIdentityClientId: opts.managedIdentityClientId,
+          })
+        : new DefaultAzureCredential();
       client = new AppConfigurationClient(appConfigEndpoint, credential);
     }
     return client;

--- a/src/drivers/azure-storage-blob.ts
+++ b/src/drivers/azure-storage-blob.ts
@@ -8,6 +8,11 @@ import { DefaultAzureCredential } from "@azure/identity";
 
 export interface AzureStorageBlobOptions {
   /**
+   * Optional client ID for managed identity. Needed if using one or more user assigned managed identity to authenticate.
+   */
+  managedIdentityClientId?: string;
+
+  /**
    * The name of the Azure Storage account.
    */
   accountName: string;
@@ -66,7 +71,11 @@ export default defineDriver((opts: AzureStorageBlobOptions) => {
         opts.connectionString
       );
     } else {
-      const credential = new DefaultAzureCredential();
+      const credential = opts.managedIdentityClientId
+        ? new DefaultAzureCredential({
+            managedIdentityClientId: opts.managedIdentityClientId,
+          })
+        : new DefaultAzureCredential();
       serviceClient = new BlobServiceClient(
         `https://${opts.accountName}.blob.core.windows.net`,
         credential

--- a/src/drivers/azure-storage-table.ts
+++ b/src/drivers/azure-storage-table.ts
@@ -9,6 +9,11 @@ import { DefaultAzureCredential } from "@azure/identity";
 
 export interface AzureStorageTableOptions {
   /**
+   * Optional client ID for managed identity. Needed if using one or more user assigned managed identity to authenticate.
+   */
+  managedIdentityClientId?: string;
+
+  /**
    * The name of the Azure Storage account.
    */
   accountName: string;
@@ -92,7 +97,11 @@ export default defineDriver((opts: AzureStorageTableOptions) => {
       // fromConnectionString is only available in Node.js runtime, not in browsers
       client = TableClient.fromConnectionString(connectionString, tableName);
     } else {
-      const credential = new DefaultAzureCredential();
+      const credential = opts.managedIdentityClientId
+        ? new DefaultAzureCredential({
+            managedIdentityClientId: opts.managedIdentityClientId,
+          })
+        : new DefaultAzureCredential();
       client = new TableClient(
         `https://${accountName}.table.core.windows.net`,
         tableName,

--- a/test/drivers/azure-key-vault.test.ts
+++ b/test/drivers/azure-key-vault.test.ts
@@ -6,7 +6,7 @@ describe.skip(
   "drivers: azure-key-vault",
   () => {
     testDriver({
-      driver: driver({ vaultName: "testunstoragevault" }),
+      driver: driver({ vaultName: "unstoragetest" }),
     });
   },
   { timeout: 80_000 }

--- a/test/drivers/azure-storage-blob.test.ts
+++ b/test/drivers/azure-storage-blob.test.ts
@@ -7,7 +7,7 @@ import { ChildProcess, exec } from "node:child_process";
 describe.skip("drivers: azure-storage-blob", () => {
   let azuriteProcess: ChildProcess;
   beforeAll(async () => {
-    azuriteProcess = exec("npx azurite-blob --silent");
+    azuriteProcess = exec("pnpm exec azurite-blob --silent");
     const client = BlobServiceClient.fromConnectionString(
       "UseDevelopmentStorage=true"
     );
@@ -20,7 +20,7 @@ describe.skip("drivers: azure-storage-blob", () => {
   testDriver({
     driver: driver({
       connectionString: "UseDevelopmentStorage=true",
-      accountName: "local",
+      accountName: "devstoreaccount1",
     }),
   });
 });

--- a/test/drivers/azure-storage-table.test.ts
+++ b/test/drivers/azure-storage-table.test.ts
@@ -8,7 +8,7 @@ describe.skip("drivers: azure-storage-table", () => {
   let azuriteProcess: ChildProcess;
 
   beforeAll(async () => {
-    azuriteProcess = exec("npx azurite-table --silent");
+    azuriteProcess = exec("pnpm exec azurite-table --silent");
     const client = TableClient.fromConnectionString(
       "UseDevelopmentStorage=true",
       "unstorage"
@@ -23,7 +23,7 @@ describe.skip("drivers: azure-storage-table", () => {
   testDriver({
     driver: driver({
       connectionString: "UseDevelopmentStorage=true",
-      accountName: "local",
+      accountName: "devstoreaccount1",
     }),
   });
 });


### PR DESCRIPTION
Enhance Azure drivers to support user-assigned managed identity authentication by adding an optional `managedIdentityClientId` parameter. This allows choosing the correct user assigned managed identity to use.

Changes:
- Added `managedIdentityClientId` option to driver interfaces to use with DefaultAzureCredential if provided
- Improved authentication flexibility for Azure services
- Fixing a bug with CosmosDB syntax that changed that didn't came up due to disabled test suites
- Fixed `removeItem` throws in CosmosDB driver
- Improved stability of Key Vault and it's test suite by introducing a wait of 750ms (average time to purge) only after `clean` if purge is provided
- Added a parameter to disablePurging for Key Vaults with enabled purge protection

All changes are tested against the local emulator (if available) and live Azure resources. 