### PR TITLE
fix(s3): missing `getInstance`

### DIFF
--- a/src/drivers/s3.ts
+++ b/src/drivers/s3.ts
@@ -162,6 +162,7 @@ export default defineDriver((options: S3DriverOptions) => {
   return {
     name: DRIVER_NAME,
     options,
+    getInstance: getAwsClient,
     getItem(key) {
       return getObject(key).then((res) => (res ? res.text() : null));
     },


### PR DESCRIPTION
Missing `getInstance` for the `S3` driver, this should allow to presign urls based on the existing driver options.
