### PR TITLE
docs(redis): update hashtags note

### DIFF
--- a/docs/2.drivers/redis.md
+++ b/docs/2.drivers/redis.md
@@ -39,9 +39,9 @@ const storage = createStorage({
 });
 ```
 
-Usage with Redis cluster (e.g. AWS ElastiCache or Azure Redis Cache):
+Usage with a Redis cluster (e.g. AWS ElastiCache or Azure Redis Cache):
 
-⚠️ If you connect to a cluster, you have to use `hastags` as prefix to avoid the redis error `CROSSSLOT Keys in request don't hash to the same slot`. This means, the prefix has to be surrounded by curly braces, which forces the keys into the same hash slot.
+⚠️ If you connect to a cluster, you have to use [`hashtags`](https://redis.io/docs/latest/operate/oss_and_stack/reference/cluster-spec/#hash-tags) as the prefix to avoid the Redis error `CROSSSLOT Keys in request don't hash to the same slot`. This means the prefix has to be surrounded by curly braces, which forces the keys into the same hash slot. You can read more [here](https://redis.io/blog/redis-clustering-best-practices-with-keys/).
 
 ```js
 const storage = createStorage({
@@ -65,7 +65,7 @@ const storage = createStorage({
 
 **Options:**
 
-- `base`: Optional prefix to use for all keys. Can be used for namespacing. Has to be used as hastag prefix for redis cluster mode.
+- `base`: Optional prefix to use for all keys. Can be used for namespacing. Has to be used as a hashtag prefix for redis cluster mode.
 - `url`: Url to use for connecting to redis. Takes precedence over `host` option. Has the format `redis://<REDIS_USER>:<REDIS_PASSWORD>@<REDIS_HOST>:<REDIS_PORT>`
 - `cluster`: List of redis nodes to use for cluster mode. Takes precedence over `url` and `host` options.
 - `clusterOptions`: Options to use for cluster mode.


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

This change mainly corrects the spelling of "hashtags" and adds links to the redis docs. (They also use "hash tags" sometimes though, so I'm not sure which is best.) 

But I think it might also be helpful to add a bit of nuance to this section. Forcing every item to the same slot will avoid the CROSSSLOT error, but isn't generally recommended. My assumption is a strategy similar to the one shown in the redis docs (slotting based on the user ID) would also work with unstorage, but there may be limitations such as `getKeys` not working. 
What are your thoughts here? (I can split this into a separate issue if it helps)