### PR TITLE
chore: fix corepack CI

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -12,8 +12,11 @@ jobs:
   autofix:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - run: corepack enable
+      - uses: actions/checkout@v4
+      # TODO (43081j): re-enable this once we upgrade from node 20.x
+      # or node 20 ships with newer corepack
+      #- run: corepack enable
+      - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
           node-version: 20

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,13 @@ jobs:
   ci:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - run: corepack enable
+      # TODO (43081j): re-enable this once we upgrade from node 20.x
+      # or node 20 ships with newer corepack
+      #- run: corepack enable
+      - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
           node-version: 20


### PR DESCRIPTION
Node 20 ships with an old corepack that causes all sorts of nonsense right now

i saw pi0 has already been in the threads around it too

for now, we can setup pnpm directly and switch back once node 20.x ships with an upgraded corepack

cc @pi0 