### PR TITLE
refactor: upgrade to  chokidar to v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "lru-cache": "^10.4.3",
     "node-fetch-native": "^1.6.6",
     "ofetch": "^1.4.1",
-    "pathe": "^2.0.3",
     "ufo": "^1.5.4"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -45,12 +45,13 @@
   },
   "dependencies": {
     "anymatch": "^3.1.3",
-    "chokidar": "^3.6.0",
+    "chokidar": "^4.0.3",
     "destr": "^2.0.3",
     "h3": "^1.15.0",
     "lru-cache": "^10.4.3",
     "node-fetch-native": "^1.6.6",
     "ofetch": "^1.4.1",
+    "pathe": "^2.0.3",
     "ufo": "^1.5.4"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,9 +29,6 @@ importers:
       ofetch:
         specifier: ^1.4.1
         version: 1.4.1
-      pathe:
-        specifier: ^2.0.3
-        version: 2.0.3
       ufo:
         specifier: ^1.5.4
         version: 1.5.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^3.1.3
         version: 3.1.3
       chokidar:
-        specifier: ^3.6.0
-        version: 3.6.0
+        specifier: ^4.0.3
+        version: 4.0.3
       destr:
         specifier: ^2.0.3
         version: 2.0.3
@@ -29,6 +29,9 @@ importers:
       ofetch:
         specifier: ^1.4.1
         version: 1.4.1
+      pathe:
+        specifier: ^2.0.3
+        version: 2.0.3
       ufo:
         specifier: ^1.5.4
         version: 1.5.4
@@ -1757,6 +1760,10 @@ packages:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
     engines: {node: '>= 8.10.0'}
 
+  chokidar@4.0.3:
+    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
+    engines: {node: '>= 14.16.0'}
+
   chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
@@ -2981,7 +2988,6 @@ packages:
 
   libsql@0.4.7:
     resolution: {integrity: sha512-T9eIRCs6b0J1SHKYIvD8+KCJMcWZ900iZyxdnSCdqxN12Z1ijzT+jY5nrk72Jw4B0HGzms2NgpryArlJqvc3Lw==}
-    cpu: [x64, arm64, wasm32]
     os: [darwin, linux, win32]
 
   lilconfig@3.1.3:
@@ -3838,6 +3844,10 @@ packages:
   readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
+
+  readdirp@4.1.2:
+    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
+    engines: {node: '>= 14.18.0'}
 
   readline-sync@1.4.10:
     resolution: {integrity: sha512-gNva8/6UAe8QYepIQH/jQ2qn91Qj0B9sYjMBBs3QOB8F2CXcKgLxQaJRP76sWVRQt+QU+8fAkCbCvjjMFu7Ycw==}
@@ -6368,6 +6378,10 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
+  chokidar@4.0.3:
+    dependencies:
+      readdirp: 4.1.2
+
   chownr@1.1.4: {}
 
   chownr@2.0.0: {}
@@ -8636,6 +8650,8 @@ snapshots:
   readdirp@3.6.0:
     dependencies:
       picomatch: 2.3.1
+
+  readdirp@4.1.2: {}
 
   readline-sync@1.4.10: {}
 

--- a/src/drivers/fs.ts
+++ b/src/drivers/fs.ts
@@ -14,6 +14,7 @@ import anymatch from "anymatch";
 
 export interface FSStorageOptions {
   base?: string;
+  /** @deprecated use `watchOptions.ignored` */
   ignore?: string[];
   readOnly?: boolean;
   noClear?: boolean;

--- a/src/drivers/fs.ts
+++ b/src/drivers/fs.ts
@@ -33,6 +33,7 @@ export default defineDriver((opts: FSStorageOptions = {}) => {
   opts = {
     ...opts,
     base: resolve(opts.base),
+    ignore: opts.ignore || ["**/node_modules/**", "**/.git/**"],
     watchOptions,
   };
 
@@ -44,11 +45,7 @@ export default defineDriver((opts: FSStorageOptions = {}) => {
   } else {
     watchOptions.ignored = [watchOptions.ignored];
   }
-  if (opts.ignore?.length) {
-    watchOptions.ignored.push((path) => anymatch(opts.ignore!, path));
-  } else {
-    watchOptions.ignored.push(/[/\\](node_modules|\.git)[/\\]/);
-  }
+  watchOptions.ignored.push((path) => anymatch(opts.ignore!, path));
 
   const r = (key: string) => {
     if (PATH_TRAVERSE_RE.test(key)) {

--- a/src/drivers/fs.ts
+++ b/src/drivers/fs.ts
@@ -45,7 +45,7 @@ export default defineDriver((opts: FSStorageOptions = {}) => {
   } else {
     watchOptions.ignored = [watchOptions.ignored];
   }
-  watchOptions.ignored.push((path) => anymatch(opts.ignore!, path));
+  watchOptions.ignored.push(anymatch(opts.ignore!));
 
   const r = (key: string) => {
     if (PATH_TRAVERSE_RE.test(key)) {

--- a/src/drivers/fs.ts
+++ b/src/drivers/fs.ts
@@ -40,7 +40,9 @@ export default defineDriver((opts: FSStorageOptions = {}) => {
   // Ignore patterns
   if (!watchOptions.ignored) {
     watchOptions.ignored = [];
-  } else if (!Array.isArray(watchOptions.ignored)) {
+  } else if (Array.isArray(watchOptions.ignored)) {
+    watchOptions.ignored = [...watchOptions.ignored];
+  } else {
     watchOptions.ignored = [watchOptions.ignored];
   }
   if (opts.ignore?.length) {

--- a/src/drivers/fs.ts
+++ b/src/drivers/fs.ts
@@ -45,13 +45,15 @@ export default defineDriver((opts: FSStorageOptions = {}) => {
   } else {
     watchOptions.ignored = [watchOptions.ignored];
   }
-  if (opts.ignore?.length) {
-    // Glob support for chokidar v4 (TODO: remove for unstorage v2)
-    watchOptions.ignored.push((path) => matchesGlob(path, opts.ignore!));
-  } else {
-    watchOptions.ignored.push((path) =>
-      /[/\\](node_modules|\.git)[/\\]/.test(path)
-    );
+  if (watchOptions.ignored.length === 0) {
+    if (opts.ignore?.length) {
+      // Glob support for chokidar v4 (TODO: remove for unstorage v2)
+      watchOptions.ignored.push((path) => matchesGlob(path, opts.ignore!));
+    } else {
+      watchOptions.ignored.push((path) =>
+        /[/\\](node_modules|\.git)[/\\]/.test(path)
+      );
+    }
   }
 
   const r = (key: string) => {

--- a/src/drivers/fs.ts
+++ b/src/drivers/fs.ts
@@ -43,8 +43,8 @@ export default defineDriver((opts: FSStorageOptions = {}) => {
   } else if (!Array.isArray(watchOptions.ignored)) {
     watchOptions.ignored = [watchOptions.ignored];
   }
-  // Glob support for chokidar v4 (TODO: remove for unstorage v2)
   if (opts.ignore?.length) {
+    // Glob support for chokidar v4 (TODO: remove for unstorage v2)
     watchOptions.ignored.push((path) => matchesGlob(path, opts.ignore!));
   } else {
     watchOptions.ignored.push((path) =>

--- a/src/drivers/fs.ts
+++ b/src/drivers/fs.ts
@@ -30,25 +30,26 @@ export default defineDriver((opts: FSStorageOptions = {}) => {
   }
 
   // Clone and apply defaults
+  const watchOptions = { ...opts.watchOptions };
   opts = {
+    ...opts,
     base: resolve(opts.base),
-    ignore: opts.ignore ?? ["**/node_modules/**", "**/.git/**"],
-    readOnly: opts.readOnly || false,
-    noClear: opts.noClear || false,
-    watchOptions: { ...opts.watchOptions },
+    watchOptions,
   };
 
-  // Apply ignored patterns
-  if (opts.ignore?.length) {
-    const watchOptions = opts.watchOptions!;
-    // Make sure ignored is an array
-    if (!watchOptions.ignored) {
-      watchOptions.ignored = [];
-    } else if (!Array.isArray(watchOptions.ignored)) {
-      watchOptions.ignored = [watchOptions.ignored];
-    }
-    // Add glob support
+  // Ignore patterns
+  if (!watchOptions.ignored) {
+    watchOptions.ignored = [];
+  } else if (!Array.isArray(watchOptions.ignored)) {
+    watchOptions.ignored = [watchOptions.ignored];
+  }
+  // Glob support for chokidar v4 (TODO: remove for unstorage v2)
+  if (watchOptions.ignored.length > 0) {
     watchOptions.ignored.push((path) => matchesGlob(path, opts.ignore!));
+  } else {
+    watchOptions.ignored.push((path) =>
+      /[/\\](node_modules|\.git)[/\\]/.test(path)
+    );
   }
 
   const r = (key: string) => {

--- a/src/drivers/fs.ts
+++ b/src/drivers/fs.ts
@@ -29,7 +29,10 @@ export default defineDriver((opts: FSStorageOptions = {}) => {
   }
 
   // Clone and apply defaults
-  const watchOptions = { ...opts.watchOptions };
+  const watchOptions: ChokidarOptions = {
+    ignoreInitial: true,
+    ...opts.watchOptions,
+  };
   opts = {
     ...opts,
     base: resolve(opts.base),
@@ -128,11 +131,7 @@ export default defineDriver((opts: FSStorageOptions = {}) => {
         return _unwatch;
       }
       await new Promise<void>((resolve, reject) => {
-        _watcher = watch(opts.base!, {
-          ignoreInitial: true,
-          ignored: opts.ignore,
-          ...opts.watchOptions,
-        })
+        _watcher = watch(opts.base!, watchOptions)
           .on("ready", () => {
             resolve();
           })

--- a/src/drivers/fs.ts
+++ b/src/drivers/fs.ts
@@ -44,7 +44,7 @@ export default defineDriver((opts: FSStorageOptions = {}) => {
     watchOptions.ignored = [watchOptions.ignored];
   }
   // Glob support for chokidar v4 (TODO: remove for unstorage v2)
-  if (watchOptions.ignored.length > 0) {
+  if (opts.ignore?.length) {
     watchOptions.ignored.push((path) => matchesGlob(path, opts.ignore!));
   } else {
     watchOptions.ignored.push((path) =>

--- a/src/drivers/fs.ts
+++ b/src/drivers/fs.ts
@@ -50,9 +50,7 @@ export default defineDriver((opts: FSStorageOptions = {}) => {
       // Glob support for chokidar v4 (TODO: remove for unstorage v2)
       watchOptions.ignored.push((path) => matchesGlob(path, opts.ignore!));
     } else {
-      watchOptions.ignored.push((path) =>
-        /[/\\](node_modules|\.git)[/\\]/.test(path)
-      );
+      watchOptions.ignored.push(/[/\\](node_modules|\.git)[/\\]/);
     }
   }
 


### PR DESCRIPTION
We initially upgraded to chokidar v4 (#489) then reverted back to #502 as a hotfix (see relevant issues)

Stability and ecosystem adoption seem now much better. The only remaining part is that chokidar v4 dropped glob support. 

This PR updates to use same `anymatch` matcher we use for listing key filtering, to also apply to `watchOptions.ignored`

- ~~If users already provided custom `ignore` option, it would be breaking change: Added via a lightweight polyfill with pathe~~
- ~~Default ignores `["**/node_modules/**", "**/.git/**"]` added using simply regex matcher~~


