### PR TITLE
fix(deno): avoid crossing package boundary in deno-kv driver

### DIFF
--- a/src/drivers/deno-kv.ts
+++ b/src/drivers/deno-kv.ts
@@ -1,5 +1,4 @@
-import { normalizeKey } from "../utils";
-import { defineDriver, createError } from "./utils/index";
+import { defineDriver, createError, normalizeKey } from "./utils/index";
 import type { Kv, KvKey } from "@deno/kv";
 
 // https://docs.deno.com/deploy/kv/manual/


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

Use `normalizeKey` in `"../utils"` will cause problems. Check the built artifacts:

Before (BUG):

```js
// drivers/deno-kv.mjs
import { normalizeKey } from "../utils";
import { defineDriver, createError } from "./utils/index.mjs";
...
```

After:

```js
// drivers/deno-kv.mjs
import { defineDriver, createError, normalizeKey } from "./utils/index.mjs";
...
```