### PR TITLE
feat(redis, vercel-kv, upstash): use non-blocking methods

### DIFF
--- a/docs/2.drivers/redis.md
+++ b/docs/2.drivers/redis.md
@@ -70,6 +70,7 @@ const storage = createStorage({
 - `cluster`: List of redis nodes to use for cluster mode. Takes precedence over `url` and `host` options.
 - `clusterOptions`: Options to use for cluster mode.
 - `ttl`: Default TTL for all items in **seconds**.
+- `scanCount`: How many keys to scan at once ([redis documentation](https://redis.io/docs/latest/commands/scan/#the-count-option)).
 
 See [ioredis](https://github.com/luin/ioredis/blob/master/API.md#new-redisport-host-options) for all available options.
 

--- a/docs/2.drivers/upstash.md
+++ b/docs/2.drivers/upstash.md
@@ -43,6 +43,7 @@ const storage = createStorage({
 - `url`: The REST URL for your Upstash Redis database. Find it in [the Upstash Redis console](https://console.upstash.com/redis/). Driver uses `UPSTASH_REDIS_REST_URL` environment by default.
 - `token`: The REST token for authentication with your Upstash Redis database. Find it in [the Upstash Redis console](https://console.upstash.com/redis/). Driver uses `UPSTASH_REDIS_REST_TOKEN` environment by default.
 - `ttl`: Default TTL for all items in **seconds**.
+- `scanCount`: How many keys to scan at once.
 
 See [@upstash/redis documentation](https://upstash.com/docs/redis/sdks/ts/overview) for all available options.
 

--- a/docs/2.drivers/vercel.md
+++ b/docs/2.drivers/vercel.md
@@ -52,6 +52,7 @@ To use, you will need to install `@vercel/kv` dependency in your project:
 - `token`: Rest API Token to use for connecting to your Vercel KV store. Default is `KV_REST_API_TOKEN`.
 - `base`: [optional] Prefix to use for all keys. Can be used for namespacing.
 - `env`: [optional] Flag to customize environment variable prefix (Default is `KV`). Set to `false` to disable env inference for `url` and `token` options.
+- `scanCount`: How many keys to scan at once.
 
 See [@upstash/redis](https://docs.upstash.com/redis/sdks/javascriptsdk/advanced) for all available options.
 

--- a/src/drivers/redis.ts
+++ b/src/drivers/redis.ts
@@ -64,7 +64,7 @@ export default defineDriver((opts: RedisOptions) => {
   const d = (key: string) => (base ? key.replace(base, "") : key); // Deprefix a key
 
   // Helper function to scan all keys matching a pattern
-  const scanAllKeys = async (pattern: string): Promise<string[]> => {
+  const scan = async (pattern: string): Promise<string[]> => {
     const client = getRedisClient();
     const keys: string[] = [];
     let cursor = "0";
@@ -101,11 +101,11 @@ export default defineDriver((opts: RedisOptions) => {
       await getRedisClient().unlink(p(key));
     },
     async getKeys(base) {
-      const keys = await scanAllKeys(p(base, "*"));
+      const keys = await scan(p(base, "*"));
       return keys.map((key) => d(key));
     },
     async clear(base) {
-      const keys = await scanAllKeys(p(base, "*"));
+      const keys = await scan(p(base, "*"));
       if (keys.length === 0) {
         return;
       }

--- a/src/drivers/redis.ts
+++ b/src/drivers/redis.ts
@@ -63,7 +63,6 @@ export default defineDriver((opts: RedisOptions) => {
   const p = (...keys: string[]) => joinKeys(base, ...keys); // Prefix a key. Uses base for backwards compatibility
   const d = (key: string) => (base ? key.replace(base, "") : key); // Deprefix a key
 
-  // Helper function to scan all keys matching a pattern
   const scan = async (pattern: string): Promise<string[]> => {
     const client = getRedisClient();
     const keys: string[] = [];


### PR DESCRIPTION
resolves #418

These changes follow official Redis recommendations for production environments and improve handling of large datasets.

- Replaced blocking del with non-blocking unlink for better performance
- Implemented cursor-based scan instead of keys to prevent server blocking

<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->
