### PR TITLE
Prevent mutation of input options in all drivers

### DIFF
--- a/src/drivers/azure-app-configuration.ts
+++ b/src/drivers/azure-app-configuration.ts
@@ -36,7 +36,8 @@ export interface AzureAppConfigurationOptions {
 
 const DRIVER_NAME = "azure-app-configuration";
 
-export default defineDriver((opts: AzureAppConfigurationOptions = {}) => {
+export default defineDriver((optsInput: AzureAppConfigurationOptions = {}) => {
+  const opts = { ...optsInput };
   const labelFilter = opts.label || "\0";
   const keyFilter = opts.prefix ? `${opts.prefix}:*` : "*";
   const p = (key: string) => (opts.prefix ? `${opts.prefix}:${key}` : key); // Prefix a key

--- a/src/drivers/azure-cosmos.ts
+++ b/src/drivers/azure-cosmos.ts
@@ -45,7 +45,8 @@ export interface AzureCosmosItem {
   modified: string | Date;
 }
 
-export default defineDriver((opts: AzureCosmosOptions) => {
+export default defineDriver((optsInput: AzureCosmosOptions) => {
+  const opts = { ...optsInput };
   let client: Container;
   const getCosmosClient = async () => {
     if (client) {

--- a/src/drivers/azure-key-vault.ts
+++ b/src/drivers/azure-key-vault.ts
@@ -26,7 +26,8 @@ export interface AzureKeyVaultOptions {
 
 const DRIVER_NAME = "azure-key-vault";
 
-export default defineDriver((opts: AzureKeyVaultOptions) => {
+export default defineDriver((optsInput: AzureKeyVaultOptions) => {
+  const opts = { ...optsInput };
   let keyVaultClient: SecretClient;
   const getKeyVaultClient = () => {
     if (keyVaultClient) {

--- a/src/drivers/azure-storage-blob.ts
+++ b/src/drivers/azure-storage-blob.ts
@@ -36,7 +36,8 @@ export interface AzureStorageBlobOptions {
 
 const DRIVER_NAME = "azure-storage-blob";
 
-export default defineDriver((opts: AzureStorageBlobOptions) => {
+export default defineDriver((optsInput: AzureStorageBlobOptions) => {
+  const opts = { ...optsInput };
   let containerClient: ContainerClient;
   const getContainerClient = () => {
     if (containerClient) {

--- a/src/drivers/azure-storage-table.ts
+++ b/src/drivers/azure-storage-table.ts
@@ -48,7 +48,8 @@ export interface AzureStorageTableOptions {
 
 const DRIVER_NAME = "azure-storage-table";
 
-export default defineDriver((opts: AzureStorageTableOptions) => {
+export default defineDriver((optsInput: AzureStorageTableOptions) => {
+  const opts = { ...optsInput };
   const {
     accountName = null,
     tableName = "unstorage",

--- a/src/drivers/db0.ts
+++ b/src/drivers/db0.ts
@@ -20,7 +20,8 @@ const DEFAULT_TABLE_NAME = "unstorage";
 
 const kExperimentalWarning = "__unstorage_db0_experimental_warning__";
 
-export default defineDriver((opts: DB0DriverOptions) => {
+export default defineDriver<DB0DriverOptions>((optsInput) => {
+  const opts = { ...optsInput };
   opts.tableName = opts.tableName || DEFAULT_TABLE_NAME;
 
   let setupPromise: Promise<void> | undefined;

--- a/src/drivers/fs-lite.ts
+++ b/src/drivers/fs-lite.ts
@@ -20,7 +20,8 @@ const PATH_TRAVERSE_RE = /\.\.:|\.\.$/;
 
 const DRIVER_NAME = "fs-lite";
 
-export default defineDriver((opts: FSStorageOptions = {}) => {
+export default defineDriver((optsInput: FSStorageOptions = {}) => {
+  const opts = { ...optsInput };
   if (!opts.base) {
     throw createRequiredError(DRIVER_NAME, "base");
   }

--- a/src/drivers/planetscale.ts
+++ b/src/drivers/planetscale.ts
@@ -18,7 +18,8 @@ interface TableSchema {
 
 const DRIVER_NAME = "planetscale";
 
-export default defineDriver((opts: PlanetscaleDriverOptions = {}) => {
+export default defineDriver<PlanetscaleDriverOptions>((optsInput = {}) => {
+  const opts = { ...optsInput };
   opts.table = opts.table || "storage";
 
   let _connection: Connection;

--- a/src/drivers/utils/index.ts
+++ b/src/drivers/utils/index.ts
@@ -1,15 +1,16 @@
 import type { Driver } from "../..";
 
-type DriverFactory<OptionsT, InstanceT> = (
-  opts: OptionsT
+export type DriverFactory<OptionsT = unknown, InstanceT = unknown> = (
+  opts: Readonly<OptionsT>
 ) => Driver<OptionsT, InstanceT>;
-interface ErrorOptions {}
 
-export function defineDriver<OptionsT = any, InstanceT = never>(
+export function defineDriver<OptionsT = unknown, InstanceT = unknown>(
   factory: DriverFactory<OptionsT, InstanceT>
 ): DriverFactory<OptionsT, InstanceT> {
   return factory;
 }
+
+interface ErrorOptions {}
 
 export function normalizeKey(
   key: string | undefined,

--- a/src/drivers/vercel-blob.ts
+++ b/src/drivers/vercel-blob.ts
@@ -27,7 +27,8 @@ export interface VercelBlobOptions {
 
 const DRIVER_NAME = "vercel-blob";
 
-export default defineDriver<VercelBlobOptions>((opts) => {
+export default defineDriver<VercelBlobOptions>((optsInput) => {
+  const opts = { ...optsInput };
   const optsBase = normalizeKey(opts?.base);
 
   const r = (...keys: string[]) =>
@@ -84,20 +85,20 @@ export default defineDriver<VercelBlobOptions>((opts) => {
         ...blobHead,
       };
     },
-    async setItem(key, value, opts) {
+    async setItem(key, value, optsSet) {
       await put(r(key), value, {
         access: "public",
         addRandomSuffix: false,
         token: getToken(),
-        ...opts,
+        ...optsSet,
       });
     },
-    async setItemRaw(key, value, opts) {
+    async setItemRaw(key, value, optsSet) {
       await put(r(key), value, {
         access: "public",
         addRandomSuffix: false,
         token: getToken(),
-        ...opts,
+        ...optsSet,
       });
     },
     async removeItem(key: string) {

--- a/src/drivers/vercel-kv.ts
+++ b/src/drivers/vercel-kv.ts
@@ -23,7 +23,8 @@ export interface VercelKVOptions extends Partial<RedisConfigNodejs> {
 
 const DRIVER_NAME = "vercel-kv";
 
-export default defineDriver<VercelKVOptions, VercelKV>((opts) => {
+export default defineDriver<VercelKVOptions, VercelKV>((optsInput) => {
+  const opts = { ...optsInput };
   const base = normalizeKey(opts?.base);
   const r = (...keys: string[]) => joinKeys(base, ...keys);
 


### PR DESCRIPTION
Ensure that input options are not mutated across all drivers by creating a new options object from the input. This change enhances the integrity of the options passed to each driver.
Resolves #566