### PR TITLE
fix(fs): exclude ignored file in key listing

### DIFF
--- a/src/drivers/utils/node-fs.ts
+++ b/src/drivers/utils/node-fs.ts
@@ -69,7 +69,7 @@ export async function readdirRecursive(
           files.push(...dirFiles.map((f) => entry.name + "/" + f));
         }
       } else {
-        if (!(ignore && ignore(entry.name))) {
+        if (!(ignore && ignore(entryPath))) {
           files.push(entry.name);
         }
       }


### PR DESCRIPTION
The ignore pattern was applied only to the file name and not to the full file path.
This caused files that should have been ignored to appear in the key listing.

Resolves #621