### PR TITLE
fix(session-storage): correct `name`

### DIFF
--- a/src/drivers/session-storage.ts
+++ b/src/drivers/session-storage.ts
@@ -7,10 +7,10 @@ const DRIVER_NAME = "session-storage";
 
 export default defineDriver((opts: SessionStorageOptions = {}) => {
   return {
-    name: DRIVER_NAME,
     ...localstorage({
       windowKey: "sessionStorage",
       ...opts,
     }),
+    name: DRIVER_NAME,
   };
 });


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

I'm working on a custom implementation that falls back to a list of drivers when the main driver are not supported. For example, localStorage might be unavailable or unreliable in some mobile devices, so sessionStorage is a second option.

I need to log the name of the driver being supported, but I noticed that  the name of the `session-storage` is replaced by `localstorage` name:

![CleanShot 2025-04-22 at 12 43 09@2x](https://github.com/user-attachments/assets/2e68e073-20bf-46eb-b273-a8eb94181efe)

This PR defines correctly the driver name of session-storage.


