### PR TITLE
fix(s3): accept `200` for delete response for better compatibility

### DIFF
--- a/src/drivers/s3.ts
+++ b/src/drivers/s3.ts
@@ -133,7 +133,7 @@ export default defineDriver((options: S3DriverOptions) => {
   // https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObject.html
   const deleteObject = async (key: string) => {
     return awsFetch(url(key), { method: "DELETE" }).then((r) => {
-      if (r?.status !== 204) {
+      if (r?.status !== 204 && r?.status !== 200) {
         throw createError(DRIVER_NAME, `Failed to delete ${key}`);
       }
     });


### PR DESCRIPTION
Some S3 compatible providers (Supabase for ex.) return 200 instead of 204 on object delete. 
This shouldn't trigger an error as 200 indicates a success as well.
