### PR TITLE
fix(driver/github): add User-Agent header for Cloudflare Workers to avoid 403

### DIFF
--- a/src/drivers/github.ts
+++ b/src/drivers/github.ts
@@ -137,11 +137,10 @@ async function fetchFiles(opts: GithubOptions) {
       `/repos/${opts.repo}/git/trees/${opts.branch}?recursive=1`,
       {
         baseURL: opts.apiURL,
-        headers: opts.token
-          ? {
-              Authorization: `token ${opts.token}`,
-            }
-          : undefined,
+        headers: {
+          'User-Agent': 'unstorage-github-driver',
+          ...(opts.token && { Authorization: `token ${opts.token}` }),
+        },
       }
     );
 


### PR DESCRIPTION
This fixes a 403 Forbidden error when using the GitHub driver in Cloudflare Workers or similar serverless environments. GitHub's API requires a `User-Agent` header, which is missing in these environments by default.

This resolves issue #643.
