### PR TITLE
feat!: `clear` support base independent of mount

### DIFF
--- a/docs/1.guide/1.index.md
+++ b/docs/1.guide/1.index.md
@@ -184,7 +184,7 @@ await storage.keys();
 
 ### `clear(base?, opts?)`
 
-Removes all stored key/values. If a base is provided, only mounts matching base will be cleared.
+Removes all stored key/values. If a base is provided, all keys matching base will be cleared.
 
 ```js
 await storage.clear();

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "mitata": "^1.0.34",
     "mlly": "^1.7.4",
     "mongodb": "^6.17.0",
-    "mongodb-memory-server": "^10.1.4",
+    "mongodb-memory-server": "=10.2.0-beta.2",
     "prettier": "^3.6.1",
     "scule": "^1.3.0",
     "types-cloudflare-worker": "^1.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -154,8 +154,8 @@ importers:
         specifier: ^6.17.0
         version: 6.17.0
       mongodb-memory-server:
-        specifier: ^10.1.4
-        version: 10.1.4
+        specifier: '=10.2.0-beta.2'
+        version: 10.2.0-beta.2
       prettier:
         specifier: ^3.6.1
         version: 3.6.1
@@ -3155,7 +3155,6 @@ packages:
 
   libsql@0.5.13:
     resolution: {integrity: sha512-5Bwoa/CqzgkTwySgqHA5TsaUDRrdLIbdM4egdPcaAnqO3aC+qAgS6BwdzuZwARA5digXwiskogZ8H7Yy4XfdOg==}
-    cpu: [x64, arm64, wasm32, arm]
     os: [darwin, linux, win32]
 
   lilconfig@3.1.3:
@@ -3389,12 +3388,12 @@ packages:
   mongodb-connection-string-url@3.0.2:
     resolution: {integrity: sha512-rMO7CGo/9BFwyZABcKAWL8UJwH/Kc2x0g72uhDWzG48URRax5TCIcJ7Rc3RZqffZzO/Gwff/jyKwCU9TN8gehA==}
 
-  mongodb-memory-server-core@10.1.4:
-    resolution: {integrity: sha512-o8fgY7ZalEd8pGps43fFPr/hkQu1L8i6HFEGbsTfA2zDOW0TopgpswaBCqDr0qD7ptibyPfB5DmC+UlIxbThzA==}
+  mongodb-memory-server-core@10.2.0-beta.2:
+    resolution: {integrity: sha512-HAGyNCEtx3IXXVt4uyJfzxWZtGjCPYRh4HYB9zHzXfb9eRDdY91eUXuCAkM48wGw5hTTZuMwSvKgm3nROZd7+w==}
     engines: {node: '>=16.20.1'}
 
-  mongodb-memory-server@10.1.4:
-    resolution: {integrity: sha512-+oKQ/kc3CX+816oPFRtaF0CN4vNcGKNjpOQe4bHo/21A3pMD+lC7Xz1EX5HP7siCX4iCpVchDMmCOFXVQSGkUg==}
+  mongodb-memory-server@10.2.0-beta.2:
+    resolution: {integrity: sha512-L1ylJJSiUd25iwA2l/jByTkwLCNWrR2nxdciiBA+IEf4oAse4wMa8JhVnQNQMHd5TO56PCqAFtSnkk65i5w57w==}
     engines: {node: '>=16.20.1'}
 
   mongodb@6.17.0:
@@ -8324,7 +8323,7 @@ snapshots:
       '@types/whatwg-url': 11.0.5
       whatwg-url: 14.2.0
 
-  mongodb-memory-server-core@10.1.4:
+  mongodb-memory-server-core@10.2.0-beta.2:
     dependencies:
       async-mutex: 0.5.0
       camelcase: 6.3.0
@@ -8348,9 +8347,9 @@ snapshots:
       - socks
       - supports-color
 
-  mongodb-memory-server@10.1.4:
+  mongodb-memory-server@10.2.0-beta.2:
     dependencies:
-      mongodb-memory-server-core: 10.1.4
+      mongodb-memory-server-core: 10.2.0-beta.2
       tslib: 2.8.1
     transitivePeerDependencies:
       - '@aws-sdk/credential-providers'

--- a/src/drivers/azure-app-configuration.ts
+++ b/src/drivers/azure-app-configuration.ts
@@ -129,13 +129,15 @@ export default defineDriver((opts: AzureAppConfigurationOptions = {}) => {
         tags: setting.tags,
       };
     },
-    async clear() {
+    async clear(base) {
       const settings = getClient().listConfigurationSettings({
         keyFilter,
         labelFilter,
         fields: ["key", "value", "label"],
       });
       for await (const setting of settings) {
+        if (!setting.key.startsWith(base)) continue;
+
         await getClient().deleteConfigurationSetting({
           key: setting.key,
           label: setting.label,

--- a/src/drivers/azure-cosmos.ts
+++ b/src/drivers/azure-cosmos.ts
@@ -129,12 +129,14 @@ export default defineDriver((opts: AzureCosmosOptions) => {
           : undefined,
       };
     },
-    async clear() {
+    async clear(base = "") {
       const iterator = (await getCosmosClient()).items.query<AzureCosmosItem>(
         `SELECT { id } from c`
       );
       const items = (await iterator.fetchAll()).resources;
       for (const item of items) {
+        if (!item.id.startsWith(base)) continue;
+
         await (await getCosmosClient())
           .item(item.id)
           .delete<AzureCosmosItem>({ consistencyLevel: "Session" });

--- a/src/drivers/azure-storage-blob.ts
+++ b/src/drivers/azure-storage-blob.ts
@@ -181,18 +181,20 @@ export default defineDriver((opts: AzureStorageBlobOptions) => {
         ...blobProperties.metadata,
       };
     },
-    async clear() {
+    async clear(base = "") {
       const iterator = getContainerClient()
         .listBlobsFlat()
         .byPage({ maxPageSize: 1000 });
       for await (const page of iterator) {
         await Promise.all(
-          page.segment.blobItems.map(
-            async (blob) =>
-              await getContainerClient().deleteBlob(blob.name, {
-                deleteSnapshots: "include",
-              })
-          )
+          page.segment.blobItems
+            .filter((blob) => blob.name.startsWith(base))
+            .map(
+              async (blob) =>
+                await getContainerClient().deleteBlob(blob.name, {
+                  deleteSnapshots: "include",
+                })
+            )
         );
       }
     },

--- a/src/drivers/capacitor-preferences.ts
+++ b/src/drivers/capacitor-preferences.ts
@@ -41,7 +41,7 @@ export default defineDriver<CapacitorPreferencesOptions, typeof Preferences>(
       },
       async clear(prefix) {
         const { keys } = await Preferences.keys();
-        const _prefix = resolveKey(prefix || "");
+        const _prefix = resolveKey(prefix ? `${prefix}:` : "");
         await Promise.all(
           keys
             .filter((key) => key.startsWith(_prefix))

--- a/src/drivers/cloudflare-kv-binding.ts
+++ b/src/drivers/cloudflare-kv-binding.ts
@@ -27,7 +27,10 @@ export default defineDriver((opts: KVOptions) => {
     const keys = [];
     let cursor: string | undefined = undefined;
     do {
-      const kvList = await binding.list({ prefix: base || undefined, cursor });
+      const kvList = await binding.list({
+        prefix: base ? `${base}:` : undefined,
+        cursor,
+      });
 
       keys.push(...kvList.keys);
       cursor = (kvList.list_complete ? undefined : kvList.cursor) as
@@ -73,10 +76,9 @@ export default defineDriver((opts: KVOptions) => {
       const binding = getKVBinding(opts.binding);
       return binding.delete(key);
     },
-    getKeys(base) {
-      return getKeys(base).then((keys) =>
-        keys.map((key) => (opts.base ? key.slice(opts.base.length) : key))
-      );
+    async getKeys(base) {
+      const keys = await getKeys(base);
+      return keys.map((key) => (opts.base ? key.slice(opts.base.length) : key));
     },
     async clear(base) {
       const binding = getKVBinding(opts.binding);

--- a/src/drivers/cloudflare-kv-http.ts
+++ b/src/drivers/cloudflare-kv-http.ts
@@ -164,7 +164,7 @@ export default defineDriver<KVHTTPOptions>((opts) => {
 
     const params: Record<string, string | undefined> = {};
     if (base || opts.base) {
-      params.prefix = r(base);
+      params.prefix = `${r(base)}:`;
     }
 
     const firstPage = await kvFetch("/keys", { params });
@@ -188,8 +188,8 @@ export default defineDriver<KVHTTPOptions>((opts) => {
     return keys;
   };
 
-  const clear = async () => {
-    const keys: string[] = await getKeys();
+  const clear = async (base?: string) => {
+    const keys: string[] = await getKeys(base);
     // Split into chunks of 10000, as the API only allows for 10,000 keys at a time
     // TODO: Avoid reduce
     // eslint-disable-next-line unicorn/no-array-reduce

--- a/src/drivers/cloudflare-r2-binding.ts
+++ b/src/drivers/cloudflare-r2-binding.ts
@@ -17,7 +17,7 @@ export default defineDriver((opts: CloudflareR2Options = {}) => {
   const getKeys = async (base?: string) => {
     const binding = getR2Binding(opts.binding);
     const kvList = await binding.list(
-      base || opts.base ? { prefix: r(base) } : undefined
+      base || opts.base ? { prefix: `${r(base)}:` } : undefined
     );
     return kvList.objects.map((obj) => obj.key);
   };

--- a/src/drivers/db0.ts
+++ b/src/drivers/db0.ts
@@ -131,9 +131,10 @@ export default defineDriver((opts: DB0DriverOptions) => {
 
       return rows?.map((r) => r.key);
     },
-    clear: async () => {
+    clear: async (base = "") => {
       await ensureTable();
-      await opts.database.sql /* sql */ `DELETE FROM {${opts.tableName}}`;
+      await opts.database
+        .sql /* sql */ `DELETE FROM {${opts.tableName}} WHERE key LIKE ${base + "%"}`;
     },
   };
 });

--- a/src/drivers/fs-lite.ts
+++ b/src/drivers/fs-lite.ts
@@ -1,6 +1,11 @@
 import { existsSync, promises as fsp, Stats } from "node:fs";
 import { resolve, join } from "node:path";
-import { createError, createRequiredError, defineDriver } from "./utils";
+import {
+  createError,
+  createRequiredError,
+  defineDriver,
+  normalizeKey,
+} from "./utils";
 import {
   readFile,
   writeFile,
@@ -79,11 +84,11 @@ export default defineDriver((opts: FSStorageOptions = {}) => {
     getKeys(_base, topts) {
       return readdirRecursive(r("."), opts.ignore, topts?.maxDepth);
     },
-    async clear() {
+    async clear(prefix) {
       if (opts.readOnly || opts.noClear) {
         return;
       }
-      await rmRecursive(r("."));
+      await rmRecursive(r(normalizeKey(prefix)));
     },
   };
 });

--- a/src/drivers/fs.ts
+++ b/src/drivers/fs.ts
@@ -2,7 +2,12 @@ import { existsSync, promises as fsp, Stats } from "node:fs";
 import { resolve, relative, join } from "node:path";
 import { FSWatcher, type ChokidarOptions, watch } from "chokidar";
 import anymatch from "anymatch";
-import { createError, createRequiredError, defineDriver } from "./utils";
+import {
+  createError,
+  createRequiredError,
+  defineDriver,
+  normalizeKey,
+} from "./utils";
 import {
   readFile,
   writeFile,
@@ -95,11 +100,11 @@ export default defineDriver((userOptions: FSStorageOptions = {}) => {
     getKeys(_base, topts) {
       return readdirRecursive(r("."), ignore, topts?.maxDepth);
     },
-    async clear() {
+    async clear(prefix) {
       if (userOptions.readOnly || userOptions.noClear) {
         return;
       }
-      await rmRecursive(r("."));
+      await rmRecursive(r(normalizeKey(prefix)));
     },
     async dispose() {
       if (_watcher) {

--- a/src/drivers/indexedb.ts
+++ b/src/drivers/indexedb.ts
@@ -1,4 +1,4 @@
-import { defineDriver } from "./utils";
+import { defineDriver, normalizeKey } from "./utils";
 import {
   get,
   set,
@@ -50,11 +50,23 @@ export default defineDriver((opts: IDBKeyvalOptions = {}) => {
     removeItem(key) {
       return del(makeKey(key), customStore);
     },
-    getKeys() {
-      return keys(customStore);
+    async getKeys() {
+      const _keys: string[] = await keys(customStore);
+      return _keys.map((key) => key.replace(base, ""));
     },
-    clear() {
-      return clear(customStore);
+    async clear(prefix) {
+      const _base = [base, prefix].filter(Boolean).join("");
+      if (_base) {
+        const _keys: string[] = await keys(customStore);
+        for (const key of _keys) {
+          console.log(key, _base);
+          if (key.startsWith(_base) && key !== normalizeKey(_base)) {
+            del(key, customStore);
+          }
+        }
+      } else {
+        await clear(customStore);
+      }
     },
   };
 });

--- a/src/drivers/localstorage.ts
+++ b/src/drivers/localstorage.ts
@@ -63,7 +63,7 @@ export default defineDriver((opts: LocalStorageOptions = {}) => {
       const _base = [base, prefix].filter(Boolean).join(":");
       if (_base) {
         for (const key of Object.keys(storage!)) {
-          if (key.startsWith(`${_base}:`)) {
+          if (key.startsWith(_base)) {
             storage?.removeItem(key);
           }
         }

--- a/src/drivers/lru-cache.ts
+++ b/src/drivers/lru-cache.ts
@@ -47,8 +47,16 @@ export default defineDriver((opts: LRUDriverOptions = {}) => {
     getKeys() {
       return [...cache.keys()];
     },
-    clear() {
-      cache.clear();
+    clear(base) {
+      if (base) {
+        for (const key of cache.keys()) {
+          if (key.startsWith(base)) {
+            cache.delete(key);
+          }
+        }
+      } else {
+        cache.clear();
+      }
     },
     dispose() {
       cache.clear();

--- a/src/drivers/memory.ts
+++ b/src/drivers/memory.ts
@@ -29,8 +29,16 @@ export default defineDriver<void, Map<string, any>>(() => {
     getKeys() {
       return [...data.keys()];
     },
-    clear() {
-      data.clear();
+    clear(base) {
+      if (base) {
+        for (const key of data.keys()) {
+          if (key.startsWith(base)) {
+            data.delete(key);
+          }
+        }
+      } else {
+        data.clear();
+      }
     },
     dispose() {
       data.clear();

--- a/src/drivers/mongodb.ts
+++ b/src/drivers/mongodb.ts
@@ -97,9 +97,9 @@ export default defineDriver((opts: MongoDbOptions) => {
     async removeItem(key) {
       await getMongoCollection().deleteOne({ key });
     },
-    async getKeys() {
+    async getKeys(base = "") {
       return await getMongoCollection()
-        .find()
+        .find({ key: { $regex: `^${base}` } })
         .project({ key: true })
         .map((d) => d.key)
         .toArray();
@@ -113,8 +113,8 @@ export default defineDriver((opts: MongoDbOptions) => {
           }
         : {};
     },
-    async clear() {
-      await getMongoCollection().deleteMany({});
+    async clear(base = "") {
+      await getMongoCollection().deleteMany({ key: { $regex: `^${base}` } });
     },
   };
 });

--- a/src/drivers/netlify-blobs.ts
+++ b/src/drivers/netlify-blobs.ts
@@ -1,4 +1,9 @@
-import { createError, createRequiredError, defineDriver } from "./utils";
+import {
+  createError,
+  createRequiredError,
+  defineDriver,
+  normalizeKey,
+} from "./utils";
 import type { GetKeysOptions } from "..";
 import { getStore, getDeployStore } from "@netlify/blobs";
 import type {
@@ -108,9 +113,9 @@ export default defineDriver((options: NetlifyStoreOptions) => {
     async clear(base?: string) {
       const client = getClient();
       return Promise.allSettled(
-        (await client.list({ prefix: base })).blobs.map((item) =>
-          client.delete(item.key)
-        )
+        (await client.list({ prefix: base })).blobs
+          .filter((item) => item.key !== normalizeKey(base))
+          .map((item) => client.delete(item.key))
       ).then(() => {});
     },
   };

--- a/src/drivers/planetscale.ts
+++ b/src/drivers/planetscale.ts
@@ -94,8 +94,11 @@ export default defineDriver((opts: PlanetscaleDriverOptions = {}) => {
       );
       return rows(res).map((r) => r.id);
     },
-    clear: async () => {
-      await getConnection().execute(`DELETE FROM ${opts.table};`);
+    clear: async (base = "") => {
+      await getConnection().execute(
+        `DELETE FROM ${opts.table} WHERE id LIKE :base;`,
+        { base: `${base}%` }
+      );
     },
   };
 });

--- a/src/drivers/uploadthing.ts
+++ b/src/drivers/uploadthing.ts
@@ -35,7 +35,7 @@ export default defineDriver<UploadThingOptions, UTApi>((opts = {}) => {
     const { files } = await client.listFiles({});
     return files
       .map((file) => file.customId)
-      .filter((k) => k && k.startsWith(base)) as string[];
+      .filter((k) => k && k.startsWith(base) && k !== base) as string[];
   };
 
   const toFile = (key: string, value: BlobPart) => {
@@ -50,8 +50,9 @@ export default defineDriver<UploadThingOptions, UTApi>((opts = {}) => {
     getInstance() {
       return getClient();
     },
-    getKeys(base) {
-      return getKeys(r(base));
+    async getKeys(prefix = "") {
+      const keys = await getKeys(r(prefix));
+      return base ? keys.map((key) => key.slice(base.length + 1)) : keys;
     },
     async hasItem(key) {
       const client = getClient();
@@ -92,7 +93,7 @@ export default defineDriver<UploadThingOptions, UTApi>((opts = {}) => {
       const client = getClient();
       await client.deleteFiles([r(key)]);
     },
-    async clear(base) {
+    async clear(base = "") {
       const client = getClient();
       const keys = await getKeys(r(base));
       await client.deleteFiles(keys);

--- a/src/drivers/utils/node-fs.ts
+++ b/src/drivers/utils/node-fs.ts
@@ -2,7 +2,11 @@ import { Dirent, existsSync, promises as fsPromises } from "node:fs";
 import { resolve, dirname } from "node:path";
 
 function ignoreNotfound(err: any) {
-  return err.code === "ENOENT" || err.code === "EISDIR" ? null : err;
+  return err.code === "ENOENT" ||
+    err.code === "EISDIR" ||
+    err.code === "ENOTDIR"
+    ? null
+    : err;
 }
 
 function ignoreExists(err: any) {

--- a/src/drivers/vercel-blob.ts
+++ b/src/drivers/vercel-blob.ts
@@ -132,7 +132,7 @@ export default defineDriver<VercelBlobOptions>((opts) => {
         const listBlobResult: Awaited<ReturnType<typeof list>> = await list({
           token: getToken(),
           cursor,
-          prefix: r(base),
+          prefix: `${r(base)}/`,
         });
         blobs.push(...listBlobResult.blobs);
         cursor = listBlobResult.cursor;

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -392,7 +392,9 @@ export function createStorage<T extends StorageValue>(
           if (m.driver.removeItem) {
             const keys = await m.driver.getKeys(m.relativeBase || "", opts);
             return Promise.all(
-              keys.map((key) => m.driver.removeItem!(key, opts))
+              keys
+                .filter((key) => filterKeyByBase(key, base))
+                .map((key) => m.driver.removeItem!(key, opts))
             );
           }
           // Readonly

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -384,7 +384,7 @@ export function createStorage<T extends StorageValue>(
     async clear(base, opts = {}) {
       base = normalizeBaseKey(base);
       await Promise.all(
-        getMounts(base, false).map(async (m) => {
+        getMounts(base, true).map(async (m) => {
           if (m.driver.clear) {
             return asyncCall(m.driver.clear, m.relativeBase, opts);
           }

--- a/test/drivers/indexedb.test.ts
+++ b/test/drivers/indexedb.test.ts
@@ -5,13 +5,12 @@ import "fake-indexeddb/auto";
 import { createStorage } from "../../src";
 
 describe("drivers: indexeddb", () => {
-  testDriver({ driver: driver({ dbName: "test-db" }) });
+  testDriver({ driver: driver({ dbName: "test-db", base: "unstorage" }) });
 
   const customStorage = createStorage({
     driver: driver({
       dbName: "custom-db",
       storeName: "custom-name",
-      base: "unstorage",
     }),
   });
 
@@ -20,7 +19,7 @@ describe("drivers: indexeddb", () => {
     await customStorage.setItem("second", "bar");
     expect(await customStorage.getItem("first")).toBe("foo");
     await customStorage.removeItem("first");
-    expect(await customStorage.getKeys()).toMatchObject(["unstorage:second"]);
+    expect(await customStorage.getKeys()).toMatchObject(["second"]);
     await customStorage.clear();
     expect(await customStorage.hasItem("second")).toBe(false);
   });

--- a/test/drivers/utils.ts
+++ b/test/drivers/utils.ts
@@ -225,17 +225,22 @@ export function testDriver(opts: TestOptions) {
   it("clear with base", async () => {
     await ctx.storage.setItem("s1:a", "test_data");
     await ctx.storage.setItem("s1-s2:a", "test_data");
-    await ctx.storage.setItem("s2:a", "test_data");
     await ctx.storage.setItem("s2:a:b", "test_data");
+    await ctx.storage.setItem("s3:a", "test_data");
 
     await ctx.storage.clear("s1");
     expect(await ctx.storage.getKeys().then((k) => k.sort())).toMatchObject(
-      ["s1-s2:a", "s2:a", "s2:a:b"].sort()
+      ["s1-s2:a", "s2:a:b", "s3:a"].sort()
     );
 
     await ctx.storage.clear("s2:a");
     expect(await ctx.storage.getKeys().then((k) => k.sort())).toMatchObject(
-      ["s1-s2:a", "s2:a"].sort()
+      ["s1-s2:a", "s3:a"].sort()
+    );
+
+    await ctx.storage.clear("s3:a");
+    expect(await ctx.storage.getKeys().then((k) => k.sort())).toMatchObject(
+      ["s1-s2:a", "s3:a"].sort()
     );
   });
 }

--- a/test/drivers/utils.ts
+++ b/test/drivers/utils.ts
@@ -68,6 +68,7 @@ export function testDriver(opts: TestOptions) {
     expect(await ctx.storage.getKeys("s1").then((k) => k.sort())).toMatchObject(
       ["s1:a"].sort()
     );
+    expect(await ctx.storage.getKeys("s1:a")).toMatchObject([]);
   });
 
   it("getKeys with depth", async () => {
@@ -211,10 +212,30 @@ export function testDriver(opts: TestOptions) {
   });
 
   it("clear", async () => {
+    await ctx.storage.setItem("s1:a", "test_data");
+    await ctx.storage.setItem("s2:a", "test_data");
+
     await ctx.storage.clear();
     expect(await ctx.storage.getKeys()).toMatchObject([]);
     // ensure we can clear empty storage as well: #162
     await ctx.storage.clear();
     expect(await ctx.storage.getKeys()).toMatchObject([]);
+  });
+
+  it("clear with base", async () => {
+    await ctx.storage.setItem("s1:a", "test_data");
+    await ctx.storage.setItem("s1-s2:a", "test_data");
+    await ctx.storage.setItem("s2:a", "test_data");
+    await ctx.storage.setItem("s2:a:b", "test_data");
+
+    await ctx.storage.clear("s1");
+    expect(await ctx.storage.getKeys().then((k) => k.sort())).toMatchObject(
+      ["s1-s2:a", "s2:a", "s2:a:b"].sort()
+    );
+
+    await ctx.storage.clear("s2:a");
+    expect(await ctx.storage.getKeys().then((k) => k.sort())).toMatchObject(
+      ["s1-s2:a", "s2:a"].sort()
+    );
   });
 }

--- a/test/drivers/utils.ts
+++ b/test/drivers/utils.ts
@@ -206,6 +206,8 @@ export function testDriver(opts: TestOptions) {
   }
 
   it("removeItem", async () => {
+    await ctx.storage.setItem("s1:a", "test_data");
+
     await ctx.storage.removeItem("s1:a", false);
     expect(await ctx.storage.hasItem("s1:a")).toBe(false);
     expect(await ctx.storage.getItem("s1:a")).toBe(null);

--- a/test/storage.test.ts
+++ b/test/storage.test.ts
@@ -130,7 +130,6 @@ describe("storage", () => {
       ]
     `);
 
-    await storage.clear("/mnt");
     await storage.unmount("/mnt");
     expect(await storage.getKeys()).toMatchObject(initialKeys);
     expect(await storage.getItem("/mnt/test.txt")).toBe("v1");


### PR DESCRIPTION
resolves #336

This makes `clear` delete all keys starting with `base` - https://github.com/unjs/unstorage/issues/336#issuecomment-3038997507

this PR also includes various other fixes which I discovered while implementing

sry for the big amount of commits - while implementing, I once deleted the whole project folder with the fs drivers and lost all my progress...

## unable to test:

azure-cosmos
azure-key-vault
azure-app-configuration

planetscale

vercel-kv - does no longer seem to be a thing

> [!IMPORTANT]  
> storage expects drivers to correctly implement `clear()` and calls `clear()` on mounts that only partialy contain data which is supposed to be deleted - meaning if clear does not respect `base` unexpected deletions can happen! 
please test carefully

