### PR TITLE
chore: add monthly compatibility workflow

### DIFF
--- a/.github/workflows/compat-tests.yml
+++ b/.github/workflows/compat-tests.yml
@@ -1,0 +1,41 @@
+name: Test Compatibility
+
+on:
+  schedule:
+    - cron: "0 0 1 * *" # 1st of every month
+
+permissions:
+  id-token: write
+
+jobs:
+  ci:
+    strategy:
+      matrix:
+        packageName:
+          - "@netlify/blobs@6.5"
+          - "@netlify/blobs@7"
+          - "@netlify/blobs@8"
+          - "@capacitor/preferences@6"
+          - "@capacitor/preferences@7"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - run: npm i -fg corepack && corepack enable
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: "pnpm"
+      - run: pnpm install
+      - run: pnpm i ${{ matrix.packageName }}
+      - run: pnpm build
+      - run: pnpm vitest
+        env:
+          VITE_UPSTASH_REDIS_REST_URL: ${{ secrets.VITE_UPSTASH_REDIS_REST_URL }}
+          VITE_UPSTASH_REDIS_REST_TOKEN: ${{ secrets.VITE_UPSTASH_REDIS_REST_TOKEN }}
+          VITE_VERCEL_BLOB_READ_WRITE_TOKEN: ${{ secrets.VITE_VERCEL_BLOB_READ_WRITE_TOKEN }}
+          VITE_CLOUDFLARE_ACC_ID: ${{ secrets.VITE_CLOUDFLARE_ACC_ID }}
+          VITE_CLOUDFLARE_KV_NS_ID: ${{ secrets.VITE_CLOUDFLARE_KV_NS_ID }}
+          VITE_CLOUDFLARE_TOKEN: ${{ secrets.VITE_CLOUDFLARE_TOKEN }}
+          VITE_UPLOADTHING_TOKEN: ${{ secrets.VITE_UPLOADTHING_TOKEN }}


### PR DESCRIPTION
Basically runs CI against various peers to ensure we're still
compatible.

@pi0 let me know if this makes sense. if you know a better way, i'm all ears. this is what i was talking about in #640.
