### PR TITLE
docs(database): correct `tableName` config key

### DIFF
--- a/docs/2.drivers/database.md
+++ b/docs/2.drivers/database.md
@@ -44,7 +44,7 @@ const database = createDatabase(
 const storage = createStorage({
   driver: dbDriver({
     database,
-    table: "custom_table_name", // Default is "unstorage"
+    tableName: "custom_table_name", // Default is "unstorage"
   }),
 });
 ```


### PR DESCRIPTION
I've changed variable `table` to `tableName` because the first one don't exist.