### PR TITLE
docs(database): correct tableName config key (2)

### DIFF
--- a/docs/2.drivers/database.md
+++ b/docs/2.drivers/database.md
@@ -44,7 +44,7 @@ const database = createDatabase(
 const storage = createStorage({
   driver: dbDriver({
     database,
-    table: "custom_table_name", // Default is "unstorage"
+    tableName: "custom_table_name", // Default is "unstorage"
   }),
 });
 ```

--- a/docs/2.drivers/database.md
+++ b/docs/2.drivers/database.md
@@ -57,4 +57,4 @@ Before first operation, driver ensures a table with columns of `id`, `value`, `b
 **Options:**
 
 - **`database`** (required): A `db0` database instance.
-- `table`: The name of the table to use. It defaults to `unstorage`.
+- `tableName`: The name of the table to use. It defaults to `unstorage`.


### PR DESCRIPTION
Oopsie, I forgot to change `table` to `tableName` in options, sorry. (#652)
