### PR TITLE
feat(drivers): add type generics to support strongly typed options of drivers

### DIFF
--- a/src/drivers/deno-kv.ts
+++ b/src/drivers/deno-kv.ts
@@ -12,6 +12,7 @@ export interface DenoKvOptions {
    */
   ttl?: number;
 }
+
 interface DenoKVSetOptions {
   /**
    * TTL in seconds.
@@ -75,12 +76,12 @@ export default defineDriver<DenoKvOptions, Promise<Deno.Kv | Kv>>(
         const value = await kv.get(r(key));
         return value.value;
       },
-      async setItem(key, value, tOptions: DenoKVSetOptions) {
+      async setItem(key, value, tOptions?: DenoKVSetOptions) {
         const ttl = normalizeTTL(tOptions?.ttl ?? opts?.ttl);
         const kv = await getKv();
         await kv.set(r(key), value, { expireIn: ttl });
       },
-      async setItemRaw(key, value, tOptions: DenoKVSetOptions) {
+      async setItemRaw(key, value, tOptions?: DenoKVSetOptions) {
         const ttl = normalizeTTL(tOptions?.ttl ?? opts?.ttl);
         const kv = await getKv();
         await kv.set(r(key), value, { expireIn: ttl });

--- a/src/drivers/netlify-blobs.ts
+++ b/src/drivers/netlify-blobs.ts
@@ -45,15 +45,20 @@ export interface NetlifyNamedStoreOptions
   deployScoped?: false;
 }
 
-export interface NetlifyGetKeysOptions extends Omit<ListOptions, "prefix" | "paginate"> {
-  maxDepth?: number
+export interface NetlifyGetKeysOptions
+  extends Omit<ListOptions, "prefix" | "paginate"> {
+  maxDepth?: number;
 }
 
-export default defineDriver<NetlifyStoreOptions, Store, {
-  setOptions: SetOptions;
-  getOptions: GetOptions
-  getKeysOptions: NetlifyGetKeysOptions
-}>((options: NetlifyStoreOptions) => {
+export default defineDriver<
+  NetlifyStoreOptions,
+  Store,
+  {
+    setOptions: SetOptions;
+    getOptions: GetOptions;
+    getKeysOptions: NetlifyGetKeysOptions;
+  }
+>((options: NetlifyStoreOptions) => {
   const { deployScoped, name, ...opts } = options;
   let store: Store;
 
@@ -114,10 +119,7 @@ export default defineDriver<NetlifyStoreOptions, Store, {
     removeItem(key) {
       return getClient().delete(key);
     },
-    async getKeys(
-      base?: string,
-      tops?: NetlifyGetKeysOptions
-    ) {
+    async getKeys(base?: string, tops?: NetlifyGetKeysOptions) {
       return (await getClient().list({ ...tops, prefix: base })).blobs.map(
         (item) => item.key
       );

--- a/src/drivers/netlify-blobs.ts
+++ b/src/drivers/netlify-blobs.ts
@@ -1,5 +1,4 @@
 import { createError, createRequiredError, defineDriver } from "./utils";
-import type { GetKeysOptions } from "..";
 import { getStore, getDeployStore } from "@netlify/blobs";
 import type {
   Store,
@@ -46,7 +45,15 @@ export interface NetlifyNamedStoreOptions
   deployScoped?: false;
 }
 
-export default defineDriver((options: NetlifyStoreOptions) => {
+export interface NetlifyGetKeysOptions extends Omit<ListOptions, "prefix" | "paginate"> {
+  maxDepth?: number
+}
+
+export default defineDriver<NetlifyStoreOptions, Store, {
+  setOptions: SetOptions;
+  getOptions: GetOptions
+  getKeysOptions: NetlifyGetKeysOptions
+}>((options: NetlifyStoreOptions) => {
   const { deployScoped, name, ...opts } = options;
   let store: Store;
 
@@ -109,7 +116,7 @@ export default defineDriver((options: NetlifyStoreOptions) => {
     },
     async getKeys(
       base?: string,
-      tops?: GetKeysOptions & Omit<ListOptions, "prefix" | "paginate">
+      tops?: NetlifyGetKeysOptions
     ) {
       return (await getClient().list({ ...tops, prefix: base })).blobs.map(
         (item) => item.key

--- a/src/drivers/utils/index.ts
+++ b/src/drivers/utils/index.ts
@@ -1,14 +1,16 @@
 import type { Driver, TransactionOpts } from "../..";
 
-type DriverFactory<OptionsT, InstanceT, TransactionOptsT extends TransactionOpts> = (
-  opts: OptionsT
-) => Driver<OptionsT, InstanceT, TransactionOptsT>;
+type DriverFactory<
+  OptionsT,
+  InstanceT,
+  TransactionOptsT extends TransactionOpts,
+> = (opts: OptionsT) => Driver<OptionsT, InstanceT, TransactionOptsT>;
 interface ErrorOptions {}
 
 export function defineDriver<
   OptionsT = any,
   InstanceT = never,
-  TransactionOptsT extends TransactionOpts = TransactionOpts
+  TransactionOptsT extends TransactionOpts = TransactionOpts,
 >(
   factory: DriverFactory<OptionsT, InstanceT, TransactionOptsT>
 ): DriverFactory<OptionsT, InstanceT, TransactionOptsT> {

--- a/src/drivers/utils/index.ts
+++ b/src/drivers/utils/index.ts
@@ -5,13 +5,16 @@ type DriverFactory<
   InstanceT,
   DriverMethodOptionsMapT extends DriverMethodOptionsMap,
   // Partial here, to not required typed options to be optional in type argument
-> = (opts: OptionsT) => Driver<OptionsT, InstanceT, Partial<DriverMethodOptionsMapT>>;
+> = (
+  opts: OptionsT
+) => Driver<OptionsT, InstanceT, Partial<DriverMethodOptionsMapT>>;
 interface ErrorOptions {}
 
 export function defineDriver<
   OptionsT = any,
   InstanceT = never,
-  DriverMethodOptionsMapT extends DriverMethodOptionsMap = DriverMethodOptionsMap,
+  DriverMethodOptionsMapT extends
+    DriverMethodOptionsMap = DriverMethodOptionsMap,
 >(
   factory: DriverFactory<OptionsT, InstanceT, DriverMethodOptionsMapT>
 ): DriverFactory<OptionsT, InstanceT, DriverMethodOptionsMapT> {

--- a/src/drivers/utils/index.ts
+++ b/src/drivers/utils/index.ts
@@ -1,18 +1,17 @@
-import type { Driver, TransactionOptions } from "../..";
+import type { Driver, TransactionOpts } from "../..";
 
-type DriverFactory<OptionsT, InstanceT, SetItemOptionsT, GetItemOptionsT> = (
+type DriverFactory<OptionsT, InstanceT, TransactionOptsT extends TransactionOpts> = (
   opts: OptionsT
-) => Driver<OptionsT, InstanceT, SetItemOptionsT, GetItemOptionsT>;
+) => Driver<OptionsT, InstanceT, TransactionOptsT>;
 interface ErrorOptions {}
 
 export function defineDriver<
   OptionsT = any,
   InstanceT = never,
-  SetItemOptionsT = TransactionOptions,
-  GetItemOptionsT = TransactionOptions,
+  TransactionOptsT extends TransactionOpts = TransactionOpts
 >(
-  factory: DriverFactory<OptionsT, InstanceT, SetItemOptionsT, GetItemOptionsT>
-): DriverFactory<OptionsT, InstanceT, SetItemOptionsT, GetItemOptionsT> {
+  factory: DriverFactory<OptionsT, InstanceT, TransactionOptsT>
+): DriverFactory<OptionsT, InstanceT, TransactionOptsT> {
   return factory;
 }
 

--- a/src/drivers/utils/index.ts
+++ b/src/drivers/utils/index.ts
@@ -1,13 +1,18 @@
-import type { Driver } from "../..";
+import type { Driver, TransactionOptions } from "../..";
 
-type DriverFactory<OptionsT, InstanceT> = (
+type DriverFactory<OptionsT, InstanceT, SetItemOptionsT, GetItemOptionsT> = (
   opts: OptionsT
-) => Driver<OptionsT, InstanceT>;
+) => Driver<OptionsT, InstanceT, SetItemOptionsT, GetItemOptionsT>;
 interface ErrorOptions {}
 
-export function defineDriver<OptionsT = any, InstanceT = never>(
-  factory: DriverFactory<OptionsT, InstanceT>
-): DriverFactory<OptionsT, InstanceT> {
+export function defineDriver<
+  OptionsT = any,
+  InstanceT = never,
+  SetItemOptionsT = TransactionOptions,
+  GetItemOptionsT = TransactionOptions,
+>(
+  factory: DriverFactory<OptionsT, InstanceT, SetItemOptionsT, GetItemOptionsT>
+): DriverFactory<OptionsT, InstanceT, SetItemOptionsT, GetItemOptionsT> {
   return factory;
 }
 

--- a/src/drivers/utils/index.ts
+++ b/src/drivers/utils/index.ts
@@ -4,7 +4,8 @@ type DriverFactory<
   OptionsT,
   InstanceT,
   TransactionOptsT extends TransactionOpts,
-> = (opts: OptionsT) => Driver<OptionsT, InstanceT, TransactionOptsT>;
+  // Partial here, to not required typed options to be optional in type argument
+> = (opts: OptionsT) => Driver<OptionsT, InstanceT, Partial<TransactionOptsT>>;
 interface ErrorOptions {}
 
 export function defineDriver<

--- a/src/drivers/utils/index.ts
+++ b/src/drivers/utils/index.ts
@@ -1,20 +1,20 @@
-import type { Driver, TransactionOpts } from "../..";
+import type { Driver, DriverMethodOptionsMap } from "../..";
 
 type DriverFactory<
   OptionsT,
   InstanceT,
-  TransactionOptsT extends TransactionOpts,
+  DriverMethodOptionsMapT extends DriverMethodOptionsMap,
   // Partial here, to not required typed options to be optional in type argument
-> = (opts: OptionsT) => Driver<OptionsT, InstanceT, Partial<TransactionOptsT>>;
+> = (opts: OptionsT) => Driver<OptionsT, InstanceT, Partial<DriverMethodOptionsMapT>>;
 interface ErrorOptions {}
 
 export function defineDriver<
   OptionsT = any,
   InstanceT = never,
-  TransactionOptsT extends TransactionOpts = TransactionOpts,
+  DriverMethodOptionsMapT extends DriverMethodOptionsMap = DriverMethodOptionsMap,
 >(
-  factory: DriverFactory<OptionsT, InstanceT, TransactionOptsT>
-): DriverFactory<OptionsT, InstanceT, TransactionOptsT> {
+  factory: DriverFactory<OptionsT, InstanceT, DriverMethodOptionsMapT>
+): DriverFactory<OptionsT, InstanceT, DriverMethodOptionsMapT> {
   return factory;
 }
 

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -26,13 +26,13 @@ interface StorageCTX {
   watchListeners: ((event: WatchEvent, key: string) => void)[];
 }
 
-export interface CreateStorageOptions {
-  driver?: Driver;
+export interface CreateStorageOptions<DriverT extends Driver = Driver> {
+  driver?: DriverT;
 }
 
-export function createStorage<T extends StorageValue>(
-  options: CreateStorageOptions = {}
-): Storage<T> {
+export function createStorage<T extends StorageValue, DriverT extends Driver = Driver>(
+  options: CreateStorageOptions<DriverT> = {}
+): Storage<T, DriverT> {
   const context: StorageCTX = {
     mounts: { "": options.driver || memory() },
     mountpoints: [""],

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -30,9 +30,10 @@ export interface CreateStorageOptions<DriverT extends Driver = Driver> {
   driver?: DriverT;
 }
 
-export function createStorage<T extends StorageValue, DriverT extends Driver = Driver>(
-  options: CreateStorageOptions<DriverT> = {}
-): Storage<T, DriverT> {
+export function createStorage<
+  T extends StorageValue,
+  DriverT extends Driver = Driver,
+>(options: CreateStorageOptions<DriverT> = {}): Storage<T, DriverT> {
   const context: StorageCTX = {
     mounts: { "": options.driver || memory() },
     mountpoints: [""],

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,73 +22,73 @@ export interface DriverFlags {
   ttl?: boolean;
 }
 
-export type TransactionOpts<
+export type DriverMethodOptionsMap<
   GetOptionsT = TransactionOptions,
   SetOptionsT = TransactionOptions,
   HasOptionsT = TransactionOptions,
   RemoveOptionsT = TransactionOptions,
   GetKeysOptionsT = TransactionOptions,
 > = {
-  getOptions?: GetOptionsT;
-  setOptions?: SetOptionsT;
-  hasOptions?: HasOptionsT;
-  removeOptions?: RemoveOptionsT;
-  getKeysOptions?: GetKeysOptionsT;
+  getOptions?: GetOptionsT ;
+  setOptions?: SetOptionsT ;
+  hasOptions?: HasOptionsT ;
+  removeOptions?: RemoveOptionsT ;
+  getKeysOptions?: GetKeysOptionsT ;
 };
 
 export interface Driver<
   OptionsT = any,
   InstanceT = any,
-  optionsT extends TransactionOpts = TransactionOpts,
+  DriverMethodOptionsMapT extends DriverMethodOptionsMap = DriverMethodOptionsMap,
 > {
   name?: string;
   flags?: DriverFlags;
   options?: OptionsT;
   getInstance?: () => InstanceT;
-  hasItem: (key: string, opts: optionsT["hasOptions"]) => MaybePromise<boolean>;
+  hasItem: (key: string, opts: DriverMethodOptionsMapT["hasOptions"]) => MaybePromise<boolean>;
   getItem: (
     key: string,
-    opts?: optionsT["getOptions"]
+    opts?: DriverMethodOptionsMapT["getOptions"]
   ) => MaybePromise<StorageValue>;
   /** @experimental */
   getItems?: (
-    items: { key: string; options?: optionsT["getOptions"] }[],
-    commonOptions?: optionsT["getOptions"]
+    items: { key: string; options?: DriverMethodOptionsMapT["getOptions"] }[],
+    commonOptions?: DriverMethodOptionsMapT["getOptions"]
   ) => MaybePromise<{ key: string; value: StorageValue }[]>;
   /** @experimental */
   getItemRaw?: (
     key: string,
-    opts: optionsT["getOptions"]
+    opts: DriverMethodOptionsMapT["getOptions"]
   ) => MaybePromise<unknown>;
   setItem?: (
     key: string,
     value: string,
-    opts: optionsT["setOptions"]
+    opts: DriverMethodOptionsMapT["setOptions"]
   ) => MaybePromise<void>;
   /** @experimental */
   setItems?: (
-    items: { key: string; value: string; options?: optionsT["setOptions"] }[],
-    commonOptions?: optionsT["setOptions"]
+    items: { key: string; value: string; options?: DriverMethodOptionsMapT["setOptions"] }[],
+    commonOptions?: DriverMethodOptionsMapT["setOptions"]
   ) => MaybePromise<void>;
   /** @experimental */
   setItemRaw?: (
     key: string,
     value: any,
-    opts: optionsT["setOptions"]
+    opts: DriverMethodOptionsMapT["setOptions"]
   ) => MaybePromise<void>;
   removeItem?: (
     key: string,
-    opts: optionsT["removeOptions"]
+    opts: DriverMethodOptionsMapT["removeOptions"]
   ) => MaybePromise<void>;
   getMeta?: (
     key: string,
-    opts: optionsT["getOptions"]
+    opts: DriverMethodOptionsMapT["getOptions"]
   ) => MaybePromise<StorageMeta | null>;
   getKeys: (
     base: string,
-    opts: optionsT["getKeysOptions"]
+    opts: DriverMethodOptionsMapT["getKeysOptions"]
   ) => MaybePromise<string[]>;
-  clear?: (base: string, opts: optionsT["removeOptions"]) => MaybePromise<void>;
+  clear?: (base: string, opts: DriverMethodOptionsMapT["removeOptions"]) => MaybePromise<void>;
   dispose?: () => MaybePromise<void>;
   watch?: (callback: WatchCallback) => MaybePromise<Unwatch>;
 }
@@ -114,7 +114,7 @@ type StorageMethodOptions<DriverT extends Driver> =
 type SetOptionsType<DriverT extends Driver> =
   unknown extends StorageMethodOptions<DriverT>["setOptions"]
     ? TransactionOptions
-    : StorageMethodOptions<DriverT>["setOptions"];
+    : StorageMethodOptions<DriverT>["setOptions"] | undefined;
 type GetOptionsType<DriverT extends Driver> =
   unknown extends StorageMethodOptions<DriverT>["getOptions"]
     ? TransactionOptions

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,39 +17,49 @@ export interface StorageMeta {
 
 export type TransactionOptions = Record<string, any>;
 
-
-
 export interface DriverFlags {
   maxDepth?: boolean;
   ttl?: boolean;
 }
 
-export type TransactionOpts<GetOptionsT = TransactionOptions, SetOptionsT = TransactionOptions, HasOptionsT = TransactionOptions, RemoveOptionsT = TransactionOptions, GetKeysOptionsT = TransactionOptions> = {
+export type TransactionOpts<
+  GetOptionsT = TransactionOptions,
+  SetOptionsT = TransactionOptions,
+  HasOptionsT = TransactionOptions,
+  RemoveOptionsT = TransactionOptions,
+  GetKeysOptionsT = TransactionOptions,
+> = {
   getOptions?: GetOptionsT;
   setOptions?: SetOptionsT;
   hasOptions?: HasOptionsT;
   removeOptions?: RemoveOptionsT;
   getKeysOptions?: GetKeysOptionsT;
-}
+};
 
 export interface Driver<
   OptionsT = any,
   InstanceT = any,
-  optionsT extends TransactionOpts = TransactionOpts
+  optionsT extends TransactionOpts = TransactionOpts,
 > {
   name?: string;
   flags?: DriverFlags;
   options?: OptionsT;
   getInstance?: () => InstanceT;
   hasItem: (key: string, opts: optionsT["hasOptions"]) => MaybePromise<boolean>;
-  getItem: (key: string, opts?: optionsT["getOptions"]) => MaybePromise<StorageValue>;
+  getItem: (
+    key: string,
+    opts?: optionsT["getOptions"]
+  ) => MaybePromise<StorageValue>;
   /** @experimental */
   getItems?: (
     items: { key: string; options?: optionsT["getOptions"] }[],
     commonOptions?: optionsT["getOptions"]
   ) => MaybePromise<{ key: string; value: StorageValue }[]>;
   /** @experimental */
-  getItemRaw?: (key: string, opts: optionsT["getOptions"]) => MaybePromise<unknown>;
+  getItemRaw?: (
+    key: string,
+    opts: optionsT["getOptions"]
+  ) => MaybePromise<unknown>;
   setItem?: (
     key: string,
     value: string,
@@ -66,12 +76,18 @@ export interface Driver<
     value: any,
     opts: optionsT["setOptions"]
   ) => MaybePromise<void>;
-  removeItem?: (key: string, opts: optionsT["removeOptions"]) => MaybePromise<void>;
+  removeItem?: (
+    key: string,
+    opts: optionsT["removeOptions"]
+  ) => MaybePromise<void>;
   getMeta?: (
     key: string,
     opts: optionsT["getOptions"]
   ) => MaybePromise<StorageMeta | null>;
-  getKeys: (base: string, opts: optionsT["getKeysOptions"]) => MaybePromise<string[]>;
+  getKeys: (
+    base: string,
+    opts: optionsT["getKeysOptions"]
+  ) => MaybePromise<string[]>;
   clear?: (base: string, opts: optionsT["removeOptions"]) => MaybePromise<void>;
   dispose?: () => MaybePromise<void>;
   watch?: (callback: WatchCallback) => MaybePromise<Unwatch>;
@@ -89,18 +105,37 @@ type StorageItemType<T, K> = K extends keyof StorageItemMap<T>
     ? StorageValue
     : T;
 
-type StorageMethodOptions<DriverT extends Driver> = DriverT extends Driver<any, any, infer MethodOptionsT>
-  ? MethodOptionsT : never;
-
+type StorageMethodOptions<DriverT extends Driver> =
+  DriverT extends Driver<any, any, infer MethodOptionsT>
+    ? MethodOptionsT
+    : never;
 
 // if options type is not set it is unknown and we default back to TransactionOptions
-type SetOptionsType<DriverT extends Driver> = unknown extends StorageMethodOptions<DriverT>["setOptions"] ? TransactionOptions : StorageMethodOptions<DriverT>["setOptions"];
-type GetOptionsType<DriverT extends Driver> = unknown extends StorageMethodOptions<DriverT>["getOptions"] ? TransactionOptions : StorageMethodOptions<DriverT>["getOptions"];
-type RemoveOptionsType<DriverT extends Driver> = unknown extends StorageMethodOptions<DriverT>["removeOptions"] ? TransactionOptions : StorageMethodOptions<DriverT>["removeOptions"];
-type GetKeysOptionsType<DriverT extends Driver> = unknown extends StorageMethodOptions<DriverT>["getKeysOptions"] ? TransactionOptions : StorageMethodOptions<DriverT>["getKeysOptions"];
-type HasOptionsType<DriverT extends Driver> = unknown extends StorageMethodOptions<DriverT>["hasOptions"] ? TransactionOptions : StorageMethodOptions<DriverT>["hasOptions"];
+type SetOptionsType<DriverT extends Driver> =
+  unknown extends StorageMethodOptions<DriverT>["setOptions"]
+    ? TransactionOptions
+    : StorageMethodOptions<DriverT>["setOptions"];
+type GetOptionsType<DriverT extends Driver> =
+  unknown extends StorageMethodOptions<DriverT>["getOptions"]
+    ? TransactionOptions
+    : StorageMethodOptions<DriverT>["getOptions"];
+type RemoveOptionsType<DriverT extends Driver> =
+  unknown extends StorageMethodOptions<DriverT>["removeOptions"]
+    ? TransactionOptions
+    : StorageMethodOptions<DriverT>["removeOptions"];
+type GetKeysOptionsType<DriverT extends Driver> =
+  unknown extends StorageMethodOptions<DriverT>["getKeysOptions"]
+    ? TransactionOptions
+    : StorageMethodOptions<DriverT>["getKeysOptions"];
+type HasOptionsType<DriverT extends Driver> =
+  unknown extends StorageMethodOptions<DriverT>["hasOptions"]
+    ? TransactionOptions
+    : StorageMethodOptions<DriverT>["hasOptions"];
 
-export interface Storage<T extends StorageValue = StorageValue, DriverT extends Driver = Driver> {
+export interface Storage<
+  T extends StorageValue = StorageValue,
+  DriverT extends Driver = Driver,
+> {
   // Item
   hasItem<
     U extends Extract<T, StorageDefinition>,
@@ -166,13 +201,13 @@ export interface Storage<T extends StorageValue = StorageValue, DriverT extends 
   >(
     key: K,
     opts?:
-      | RemoveOptionsType<DriverT> & { removeMeta?: boolean }
+      | (RemoveOptionsType<DriverT> & { removeMeta?: boolean })
       | boolean /* legacy: removeMeta */
   ): Promise<void>;
   removeItem(
     key: string,
     opts?:
-      | RemoveOptionsType<DriverT> & { removeMeta?: boolean } 
+      | (RemoveOptionsType<DriverT> & { removeMeta?: boolean })
       | boolean /* legacy: removeMeta */
   ): Promise<void>;
 
@@ -190,7 +225,10 @@ export interface Storage<T extends StorageValue = StorageValue, DriverT extends 
   ) => Promise<void>;
   removeMeta: (key: string, opts?: RemoveOptionsType<DriverT>) => Promise<void>;
   // Keys
-  getKeys: (base?: string, opts?: GetKeysOptionsType<DriverT>) => Promise<string[]>;
+  getKeys: (
+    base?: string,
+    opts?: GetKeysOptionsType<DriverT>
+  ) => Promise<string[]>;
   // Utils
   clear: (base?: string, opts?: RemoveOptionsType<DriverT>) => Promise<void>;
   dispose: () => Promise<void>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,23 +29,27 @@ export type DriverMethodOptionsMap<
   RemoveOptionsT = TransactionOptions,
   GetKeysOptionsT = TransactionOptions,
 > = {
-  getOptions?: GetOptionsT ;
-  setOptions?: SetOptionsT ;
-  hasOptions?: HasOptionsT ;
-  removeOptions?: RemoveOptionsT ;
-  getKeysOptions?: GetKeysOptionsT ;
+  getOptions?: GetOptionsT;
+  setOptions?: SetOptionsT;
+  hasOptions?: HasOptionsT;
+  removeOptions?: RemoveOptionsT;
+  getKeysOptions?: GetKeysOptionsT;
 };
 
 export interface Driver<
   OptionsT = any,
   InstanceT = any,
-  DriverMethodOptionsMapT extends DriverMethodOptionsMap = DriverMethodOptionsMap,
+  DriverMethodOptionsMapT extends
+    DriverMethodOptionsMap = DriverMethodOptionsMap,
 > {
   name?: string;
   flags?: DriverFlags;
   options?: OptionsT;
   getInstance?: () => InstanceT;
-  hasItem: (key: string, opts: DriverMethodOptionsMapT["hasOptions"]) => MaybePromise<boolean>;
+  hasItem: (
+    key: string,
+    opts: DriverMethodOptionsMapT["hasOptions"]
+  ) => MaybePromise<boolean>;
   getItem: (
     key: string,
     opts?: DriverMethodOptionsMapT["getOptions"]
@@ -67,7 +71,11 @@ export interface Driver<
   ) => MaybePromise<void>;
   /** @experimental */
   setItems?: (
-    items: { key: string; value: string; options?: DriverMethodOptionsMapT["setOptions"] }[],
+    items: {
+      key: string;
+      value: string;
+      options?: DriverMethodOptionsMapT["setOptions"];
+    }[],
     commonOptions?: DriverMethodOptionsMapT["setOptions"]
   ) => MaybePromise<void>;
   /** @experimental */
@@ -88,7 +96,10 @@ export interface Driver<
     base: string,
     opts: DriverMethodOptionsMapT["getKeysOptions"]
   ) => MaybePromise<string[]>;
-  clear?: (base: string, opts: DriverMethodOptionsMapT["removeOptions"]) => MaybePromise<void>;
+  clear?: (
+    base: string,
+    opts: DriverMethodOptionsMapT["removeOptions"]
+  ) => MaybePromise<void>;
   dispose?: () => MaybePromise<void>;
   watch?: (callback: WatchCallback) => MaybePromise<Unwatch>;
 }

--- a/test/drivers/utils.ts
+++ b/test/drivers/utils.ts
@@ -11,7 +11,7 @@ export interface TestContext {
   driver: Driver;
 }
 
-export interface TestOptions{
+export interface TestOptions {
   driver: Driver<any, any, any> | (() => Driver<any, any, any>);
   noKeysSupport?: boolean;
   additionalTests?: (ctx: TestContext) => void;

--- a/test/drivers/utils.ts
+++ b/test/drivers/utils.ts
@@ -11,8 +11,8 @@ export interface TestContext {
   driver: Driver;
 }
 
-export interface TestOptions {
-  driver: Driver | (() => Driver);
+export interface TestOptions{
+  driver: Driver<any, any, any> | (() => Driver<any, any, any>);
   noKeysSupport?: boolean;
   additionalTests?: (ctx: TestContext) => void;
 }


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

Implements support for typed options from driver. Resolves #660 

So I think I better explain what is going on here.

I added an optional type argument for the drivers to declare their option types (get, set, remove, has, getKeys).
This type argument is passed to the Storage (via the driver) where the actual type is then extracted and passed onto the methods.
It achives strongly typed options in the methods, for example `get` from the specific driver used.

I tried to deduce what kind of options are needed in what method, but please double check them in the `Driver` and `Storage` types.

As a side note, there is no type safety for the options inside the `createStorage` function, though as we currently always (as far as I tell) just pass them right back into the driver, there should be no issues.

As part of this I had to add these types to the `netlify-blob` driver. There you can see the strongly typed options for the `set`, `get` and `getKeys` in action.

From here we can go into each driver and set their option types to get strong type support in their option methods.

I hope my explanation makes sense.
Please take a look.
If you have any questions, please feel free to ask right away!