### PR TITLE
fix(prefixStorage): strip prefix from `keys()` 

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -48,6 +48,8 @@ export function prefixStorage<T extends StorageValue>(
       // Remove Prefix
       .then((keys) => keys.map((key) => key.slice(base.length)));
 
+  nsStorage.keys = nsStorage.getKeys;
+
   nsStorage.getItems = async <U extends T>(
     items: (string | { key: string; options?: TransactionOptions })[],
     commonOptions?: TransactionOptions


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

This applies the same prefix stripping done to `getItems()` to it's alias `keys()`
https://github.com/unjs/unstorage/blob/da88311064cfb4bf41c4114b015c5bcb50906c8c/src/storage.ts#L474-L475

`prefixStorage()` is used with Nitro Storage