### PR TITLE
fix(vercel-blob): expose driver `options` 

### DIFF
--- a/src/drivers/vercel-blob.ts
+++ b/src/drivers/vercel-blob.ts
@@ -60,6 +60,7 @@ export default defineDriver<VercelBlobOptions>((opts) => {
 
   return {
     name: DRIVER_NAME,
+    options: opts,
     async hasItem(key: string) {
       const blob = await get(key);
       return !!blob;


### PR DESCRIPTION
The Vercel Blob driver was missing the options