### PR TITLE
fix(fs): ensure directory exists before watching

### DIFF
--- a/src/drivers/fs.ts
+++ b/src/drivers/fs.ts
@@ -9,6 +9,7 @@ import {
   readdirRecursive,
   rmRecursive,
   unlink,
+  ensuredir,
 } from "./utils/node-fs";
 
 export interface FSStorageOptions {
@@ -110,6 +111,7 @@ export default defineDriver((userOptions: FSStorageOptions = {}) => {
       if (_watcher) {
         return _unwatch;
       }
+      await ensuredir(base);
       await new Promise<void>((resolve, reject) => {
         const watchOptions: ChokidarOptions = {
           ignoreInitial: true,


### PR DESCRIPTION
resolves https://github.com/unjs/unstorage/issues/684
(For `v1`)