### PR TITLE
build: create `d.cts` and `d.mts` type declarations

### DIFF
--- a/build.config.ts
+++ b/build.config.ts
@@ -44,7 +44,6 @@ const scan = async (dir: string) => {
       const content = await fs.readFile(filePath, "utf8");
       await fs.writeFile(filePath.replace(".d.ts", ".d.cts"), content);
       await fs.writeFile(filePath.replace(".d.ts", ".d.mts"), content);
-      await fs.unlink(filePath);
     }
   }
 };


### PR DESCRIPTION
if we are not specifying a single types file with `"types"`, we must match the extension for `.cjs` and `.mjs` or types will not be resolved at all in bundler module resolution

([example](https://github.com/elk-zone/elk/actions/runs/19540421277/job/55944965381?pr=3408))

if we need to support node10 I can also keep `.d.ts` but at the moment this PR removes .d.ts

closes https://github.com/unjs/unstorage/pull/702