### PR TITLE
chore(docs): ignore formatting files with mdc syntax

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://unpkg.com/oxfmt/configuration_schema.json",
-  "ignorePatterns": ["src/_drivers.ts", "CHANGELOG.md"]
+  "ignorePatterns": ["src/_drivers.ts", "CHANGELOG.md", "docs/2.drivers/0.index.md"]
 }

--- a/docs/2.drivers/0.index.md
+++ b/docs/2.drivers/0.index.md
@@ -7,212 +7,148 @@ icon: icon-park-outline:hard-disk
 > Unstorage has several built-in drivers.
 
 ::card-group
-::card
-
----
-
-icon: mdi:microsoft-azure
-to: /drivers/azure
-title: Azure
-color: gray
-
----
-
-Store data in Azure available storages.
-::
-::card
-
----
-
-icon: ph:browser-thin
-to: /drivers/browser
-title: Browser
-color: gray
-
----
-
-Store data in browser storages (localStorage, sessionStorage, indexedDB).
-::
-::card
-
----
-
-icon: nonicons:capacitor-16
-to: /drivers/capacitor-preferences
-title: Capacitor Preferences
-color: gray
-
----
-
-Store data via Capacitor Preferences API on mobile devices or local storage on the web.
-::
-::card
-
----
-
-icon: devicon-plain:cloudflareworkers
-to: /drivers/cloudflare
-title: Cloudflare
-color: gray
-
----
-
-Store data in Cloudflare KV or R2 storage.
-::
-::card
-
----
-
-icon: ph:file-light
-to: /drivers/fs
-title: Filesystem (Node.js)
-color: gray
-
----
-
-Store data in the filesystem using Node.js API.
-::
-::card
-
----
-
-icon: mdi:github
-to: /drivers/github
-title: GitHub
-color: gray
-
----
-
-Map files from a remote github repository (readonly).
-::
-::card
-
----
-
-icon: ic:baseline-http
-to: /drivers/http
-title: HTTP
-color: gray
-
----
-
-Use a remote HTTP/HTTPS endpoint as data storage.
-::
-::card
-
----
-
-icon: material-symbols:cached-rounded
-to: /drivers/lru-cache
-title: LRU Cache
-color: gray
-
----
-
-Keeps cached data in memory using LRU Cache.
-::
-::card
-
----
-
-icon: bi:memory
-to: /drivers/memory
-title: Memory
-color: gray
-
----
-
-Keep data in memory.
-::
-::card
-
----
-
-icon: teenyicons:mongodb-outline
-to: /drivers/mongodb
-title: MongoDB
-color: gray
-
----
-
-Store data in MongoDB database.
-::
-::card
-
----
-
-icon: teenyicons:netlify-solid
-to: /drivers/netlify
-title: Netlify Blobs
-color: gray
-
----
-
-Store data in Netlify Blobs.
-::
-::card
-
----
-
-icon: carbon:overlay
-to: /drivers/overlay
-title: Overlay
-color: gray
-
----
-
-Create a multi-layer overlay driver.
-::
-::card
-
----
-
-icon: simple-icons:planetscale
-to: /drivers/planetscale
-title: PlanetScale
-color: gray
-
----
-
-Store data in PlanetScale database.
-::
-::card
-
----
-
-icon: simple-icons:redis
-to: /drivers/redis
-title: Redis
-color: gray
-
----
-
-Store data in Redis.
-::
-::card
-
----
-
-icon: ph:database
-to: /drivers/database
-title: SQL Database
-color: gray
-
----
-
-Store data in SQL database.
-::
-::card
-
----
-
-icon: gg:vercel
-to: /drivers/vercel
-title: Vercel KV
-color: gray
-
----
-
-Store data in Vercel KV.
-::
+  ::card
+  ---
+  icon: mdi:microsoft-azure
+  to: /drivers/azure
+  title: Azure
+  color: gray
+  ---
+  Store data in Azure available storages.
+  ::
+  ::card
+  ---
+  icon: ph:browser-thin
+  to: /drivers/browser
+  title: Browser
+  color: gray
+  ---
+  Store data in browser storages (localStorage, sessionStorage, indexedDB).
+  ::
+  ::card
+  ---
+  icon: nonicons:capacitor-16
+  to: /drivers/capacitor-preferences
+  title: Capacitor Preferences
+  color: gray
+  ---
+  Store data via Capacitor Preferences API on mobile devices or local storage on the web.
+  ::
+  ::card
+  ---
+  icon: devicon-plain:cloudflareworkers
+  to: /drivers/cloudflare
+  title: Cloudflare
+  color: gray
+  ---
+  Store data in Cloudflare KV or R2 storage.
+  ::
+  ::card
+  ---
+  icon: ph:file-light
+  to: /drivers/fs
+  title: Filesystem (Node.js)
+  color: gray
+  ---
+  Store data in the filesystem using Node.js API.
+  ::
+  ::card
+  ---
+  icon: mdi:github
+  to: /drivers/github
+  title: GitHub
+  color: gray
+  ---
+  Map files from a remote github repository (readonly).
+  ::
+  ::card
+  ---
+  icon: ic:baseline-http
+  to: /drivers/http
+  title: HTTP
+  color: gray
+  ---
+  Use a remote HTTP/HTTPS endpoint as data storage.
+  ::
+  ::card
+  ---
+  icon: material-symbols:cached-rounded
+  to: /drivers/lru-cache
+  title: LRU Cache
+  color: gray
+  ---
+  Keeps cached data in memory using LRU Cache.
+  ::
+  ::card
+  ---
+  icon: bi:memory
+  to: /drivers/memory
+  title: Memory
+  color: gray
+  ---
+  Keep data in memory.
+  ::
+  ::card
+  ---
+  icon: teenyicons:mongodb-outline
+  to: /drivers/mongodb
+  title: MongoDB
+  color: gray
+  ---
+  Store data in MongoDB database.
+  ::
+  ::card
+  ---
+  icon: teenyicons:netlify-solid
+  to: /drivers/netlify
+  title: Netlify Blobs
+  color: gray
+  ---
+  Store data in Netlify Blobs.
+  ::
+  ::card
+  ---
+  icon: carbon:overlay
+  to: /drivers/overlay
+  title: Overlay
+  color: gray
+  ---
+  Create a multi-layer overlay driver.
+  ::
+  ::card
+  ---
+  icon: simple-icons:planetscale
+  to: /drivers/planetscale
+  title: PlanetScale
+  color: gray
+  ---
+  Store data in PlanetScale database.
+  ::
+  ::card
+  ---
+  icon: simple-icons:redis
+  to: /drivers/redis
+  title: Redis
+  color: gray
+  ---
+  Store data in Redis.
+  ::
+  ::card
+  ---
+  icon: ph:database
+  to: /drivers/database
+  title: SQL Database
+  color: gray
+  ---
+  Store data in SQL database.
+  ::
+  ::card
+  ---
+  icon: gg:vercel
+  to: /drivers/vercel
+  title: Vercel KV
+  color: gray
+  ---
+  Store data in Vercel KV.
+  ::
 ::


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

resolves https://github.com/unjs/unstorage/issues/745

The `oxcfmt` adds blank lines around the `---` marker, which breaks how [remark-mdc](https://github.com/nuxt-content/remark-mdc) parses the content.

For now, just temporarily disable formatting for specific md files. This might be a feature request for `remark-mdc`, but it's unclear if it would follow the [standard spec](https://github.com/nuxt-content/remark-mdc/issues/53) 🤔
