### PR TITLE
feat(drivers): add Tauri Store driver and docs

### DIFF
--- a/docs/2.drivers/0.index.md
+++ b/docs/2.drivers/0.index.md
@@ -32,6 +32,7 @@ Without a `driver` option, `createStorage()` uses the [memory driver](/drivers/m
 | [Session storage](/drivers/browser) | `unstorage/drivers/session-storage` | Browser `sessionStorage`. |
 | [IndexedDB](/drivers/browser#indexeddb) | `unstorage/drivers/indexeddb` | Browser database through `idb-keyval`. |
 | [Capacitor Preferences](/drivers/capacitor-preferences) | `unstorage/drivers/capacitor-preferences` | Mobile preferences and web fallback. |
+| [Tauri Store](/drivers/tauri) | `unstorage/drivers/tauri` | Store files managed by the Tauri Store plugin. |
 | [Deno KV](/drivers/deno) | `unstorage/drivers/deno-kv` | Deno runtime and Deno Deploy. |
 | [Deno KV for Node.js](/drivers/deno#usage-nodejs) | `unstorage/drivers/deno-kv-node` | Remote or local Deno KV through `@deno/kv`. |
 | [LRU Cache](/drivers/lru-cache) | `unstorage/drivers/lru-cache` | Bounded in-process cache. |

--- a/docs/2.drivers/tauri.md
+++ b/docs/2.drivers/tauri.md
@@ -1,0 +1,43 @@
+---
+icon: simple-icons:tauri
+---
+
+# Tauri Store
+
+> Store data via [Tauri Store Plugin](https://tauri.app/plugin/store) in Tauri desktop/mobile apps.
+
+::read-more{to="https://tauri.app/plugin/store"}
+Learn more about Tauri Store Plugin.
+::
+
+## Usage
+
+**Driver name:** `tauri`
+
+Install the Tauri store plugin in your Tauri project, then install unstorage:
+
+:pm-install{name="@tauri-apps/plugin-store"}
+
+Usage:
+
+```js
+import { createStorage } from "unstorage";
+import tauriDriver from "unstorage/drivers/tauri";
+
+const storage = createStorage({
+  driver: tauriDriver({
+    path: "store.json",
+    base: "app",
+    options: { autoSave: 100 },
+  }),
+});
+```
+
+**Options:**
+
+- `path`: Path to the store file (e.g. `"store.json"`). Required.
+- `base`: Optional prefix for all keys (namespace).
+- `options`: Optional [StoreOptions](https://tauri.app/plugin/store/) from `@tauri-apps/plugin-store` (e.g. `autoSave`: `false` to disable auto-save, or a number for debounce ms; default 100).
+- `lib`: An imported `@tauri-apps/plugin-store` module or a function that returns it.
+
+The driver supports `watch` via the store's `onChange` listener for key updates.

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@libsql/client": "^0.17.4",
     "@netlify/blobs": "^11",
     "@planetscale/database": "^1.20.1",
+    "@tauri-apps/plugin-store": "^2.4.4",
     "@types/deno": "^2.7.0",
     "@types/ioredis-mock": "^8.2.8",
     "@types/jsdom": "^30.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       '@planetscale/database':
         specifier: ^1.20.1
         version: 1.20.1
+      '@tauri-apps/plugin-store':
+        specifier: ^2.4.4
+        version: 2.4.4
       '@types/deno':
         specifier: ^2.7.0
         version: 2.7.0
@@ -1497,6 +1500,12 @@ packages:
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@tauri-apps/api@2.11.1':
+    resolution: {integrity: sha512-M2FPuYND2m+wh5hfW9ZpSdxMPdEJovPBWwoHJmwUpysTYNHaOkVFN419m/K0LIgjb/7KU2vBgsUepJWugQCvAA==}
+
+  '@tauri-apps/plugin-store@2.4.4':
+    resolution: {integrity: sha512-oxSMaj/QpVfJcBMYX5aOQV94fWvga0MwQMfD6TLlbK2dh+ShPWAzefd8HWXhvOKjPRJdGVAkW7ZGO76JzzjaDA==}
 
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
@@ -5719,6 +5728,12 @@ snapshots:
   '@standard-schema/spec@1.0.0-beta.4': {}
 
   '@standard-schema/spec@1.1.0': {}
+
+  '@tauri-apps/api@2.11.1': {}
+
+  '@tauri-apps/plugin-store@2.4.4':
+    dependencies:
+      '@tauri-apps/api': 2.11.1
 
   '@types/chai@5.2.3':
     dependencies:

--- a/src/_drivers.ts
+++ b/src/_drivers.ts
@@ -30,12 +30,13 @@ import type { PlanetscaleDriverOptions as PlanetscaleOptions } from "unstorage/d
 import type { RedisOptions } from "unstorage/drivers/redis";
 import type { S3DriverOptions as S3Options } from "unstorage/drivers/s3";
 import type { SessionStorageOptions } from "unstorage/drivers/session-storage";
+import type { TauriStorageDriverOptions as TauriOptions } from "unstorage/drivers/tauri";
 import type { UploadThingOptions as UploadthingOptions } from "unstorage/drivers/uploadthing";
 import type { UpstashOptions } from "unstorage/drivers/upstash";
 import type { VercelBlobOptions } from "unstorage/drivers/vercel-blob";
 import type { VercelCacheOptions as VercelRuntimeCacheOptions } from "unstorage/drivers/vercel-runtime-cache";
 
-export type BuiltinDriverName = "azure-app-configuration" | "azureAppConfiguration" | "azure-cosmos" | "azureCosmos" | "azure-key-vault" | "azureKeyVault" | "azure-storage-blob" | "azureStorageBlob" | "azure-storage-table" | "azureStorageTable" | "capacitor-preferences" | "capacitorPreferences" | "cloudflare-cache-binding" | "cloudflareCacheBinding" | "cloudflare-kv-binding" | "cloudflareKVBinding" | "cloudflare-kv-http" | "cloudflareKVHttp" | "cloudflare-r2-binding" | "cloudflareR2Binding" | "db0" | "deno-kv-node" | "denoKVNode" | "deno-kv" | "denoKV" | "fs-lite" | "fsLite" | "fs" | "github" | "http" | "indexedb" | "localstorage" | "lru-cache" | "lruCache" | "memory" | "mongodb" | "netlify-blobs" | "netlifyBlobs" | "null" | "overlay" | "planetscale" | "redis" | "s3" | "session-storage" | "sessionStorage" | "uploadthing" | "upstash" | "vercel-blob" | "vercelBlob" | "vercel-runtime-cache" | "vercelRuntimeCache";
+export type BuiltinDriverName = "azure-app-configuration" | "azureAppConfiguration" | "azure-cosmos" | "azureCosmos" | "azure-key-vault" | "azureKeyVault" | "azure-storage-blob" | "azureStorageBlob" | "azure-storage-table" | "azureStorageTable" | "capacitor-preferences" | "capacitorPreferences" | "cloudflare-cache-binding" | "cloudflareCacheBinding" | "cloudflare-kv-binding" | "cloudflareKVBinding" | "cloudflare-kv-http" | "cloudflareKVHttp" | "cloudflare-r2-binding" | "cloudflareR2Binding" | "db0" | "deno-kv-node" | "denoKVNode" | "deno-kv" | "denoKV" | "fs-lite" | "fsLite" | "fs" | "github" | "http" | "indexedb" | "localstorage" | "lru-cache" | "lruCache" | "memory" | "mongodb" | "netlify-blobs" | "netlifyBlobs" | "null" | "overlay" | "planetscale" | "redis" | "s3" | "session-storage" | "sessionStorage" | "tauri" | "uploadthing" | "upstash" | "vercel-blob" | "vercelBlob" | "vercel-runtime-cache" | "vercelRuntimeCache";
 
 export type BuiltinDriverOptions = {
   "azure-app-configuration": AzureAppConfigurationOptions;
@@ -81,6 +82,7 @@ export type BuiltinDriverOptions = {
   "s3": S3Options;
   "session-storage": SessionStorageOptions;
   "sessionStorage": SessionStorageOptions;
+  "tauri": TauriOptions;
   "uploadthing": UploadthingOptions;
   "upstash": UpstashOptions;
   "vercel-blob": VercelBlobOptions;
@@ -135,6 +137,7 @@ export const builtinDrivers = {
   "s3": "unstorage/drivers/s3",
   "session-storage": "unstorage/drivers/session-storage",
   "sessionStorage": "unstorage/drivers/session-storage",
+  "tauri": "unstorage/drivers/tauri",
   "uploadthing": "unstorage/drivers/uploadthing",
   "upstash": "unstorage/drivers/upstash",
   "vercel-blob": "unstorage/drivers/vercel-blob",
@@ -234,6 +237,9 @@ export const builtinDriverDependencies: Partial<Record<BuiltinDriverName, Driver
   },
   "s3": {
     lib: { name: "aws4fetch", version: "^1.0.20" },
+  },
+  "tauri": {
+    lib: { name: "@tauri-apps/plugin-store", version: "^2.0.0" },
   },
   "uploadthing": {
     lib: { name: "uploadthing", import: "uploadthing/server", version: "^7.7.4" },

--- a/src/drivers/tauri.ts
+++ b/src/drivers/tauri.ts
@@ -1,0 +1,110 @@
+import {
+  type DriverDependencies,
+  type DriverFactory,
+  importLib,
+  joinKeys,
+  type LibImport,
+  normalizeKey,
+} from "./utils/index.ts";
+
+export interface TauriStorageDriverOptions {
+  /**
+   * Path to the store file (e.g. `"store.json"`).
+   */
+  path: string;
+  /**
+   * Optional [StoreOptions](https://tauri.app/plugin/store/) (e.g. `autoSave`).
+   */
+  options?: import("@tauri-apps/plugin-store").StoreOptions;
+  /**
+   * Optional prefix for all keys (namespace).
+   */
+  base?: string;
+  /**
+   * Optionally provide the [`@tauri-apps/plugin-store`](https://www.npmjs.com/package/@tauri-apps/plugin-store)
+   * library to avoid dynamically importing it.
+   */
+  lib?: LibImport<typeof import("@tauri-apps/plugin-store")>;
+}
+
+export const DRIVER_DEPENDENCIES: DriverDependencies = {
+  lib: { name: "@tauri-apps/plugin-store", version: "^2.0.0" },
+};
+
+const DRIVER_NAME = "tauri";
+
+type TauriStore = import("@tauri-apps/plugin-store").Store;
+
+const driver: DriverFactory<TauriStorageDriverOptions, Promise<TauriStore>> = (opts) => {
+  const base = normalizeKey(opts?.base || "");
+  const resolveKey = (key: string) => joinKeys(base, key);
+
+  const storePromise = importLib(
+    DRIVER_NAME,
+    "@tauri-apps/plugin-store",
+    opts?.lib,
+    () => import("@tauri-apps/plugin-store"),
+  ).then((lib) => lib.load(opts.path, opts.options));
+
+  return {
+    name: DRIVER_NAME,
+    options: opts,
+    getInstance: () => storePromise,
+    async hasItem(key) {
+      const store = await storePromise;
+      return store.has(resolveKey(key));
+    },
+    async getItem(key) {
+      const store = await storePromise;
+      return store.get(resolveKey(key)) ?? null;
+    },
+    async setItem(key, value) {
+      const store = await storePromise;
+      await store.set(resolveKey(key), value);
+    },
+    async removeItem(key) {
+      const store = await storePromise;
+      await store.delete(resolveKey(key));
+    },
+    async getKeys(basePrefix) {
+      const store = await storePromise;
+      const prefix = resolveKey(basePrefix || "");
+      const allKeys = await store.keys();
+      if (!prefix) {
+        return base
+          ? allKeys
+              .filter((k) => k === base || k.startsWith(base + ":"))
+              .map((k) => k.slice(base.length + 1))
+              .filter(Boolean)
+          : allKeys;
+      }
+      return allKeys
+        .filter((k) => k === prefix || k.startsWith(prefix + ":"))
+        .map((k) => (base ? k.slice(base.length + 1) : k))
+        .filter(Boolean);
+    },
+    async clear(basePrefix) {
+      const store = await storePromise;
+      const prefix = resolveKey(basePrefix || "");
+      const allKeys = await store.keys();
+      const toRemove = prefix
+        ? allKeys.filter((k) => k === prefix || k.startsWith(prefix + ":"))
+        : base
+          ? allKeys.filter((k) => k === base || k.startsWith(base + ":"))
+          : allKeys;
+      await Promise.all(toRemove.map((k) => store.delete(k)));
+    },
+    async watch(callback) {
+      const store = await storePromise;
+      const unlisten = await store.onChange((key, value) => {
+        if (!base || key === base || key.startsWith(base + ":")) {
+          const eventKey = base ? key.slice(base.length + 1) : key;
+          callback(value === null ? "remove" : "update", eventKey);
+        }
+      });
+      return () => unlisten();
+    },
+  };
+};
+
+export default driver;

--- a/test/drivers/tauri.test.ts
+++ b/test/drivers/tauri.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from "vitest";
+import driver, { type TauriStorageDriverOptions } from "../../src/drivers/tauri.ts";
+import { testDriver } from "./utils.ts";
+
+function createMockStore() {
+  const data = new Map<string, unknown>();
+  const onChangeListeners = new Set<(key: string, value: unknown) => void>();
+  const store = {
+    has: (key: string) => Promise.resolve(data.has(key)),
+    get: (key: string) => Promise.resolve(data.get(key) ?? null),
+    set: (key: string, value: unknown) => Promise.resolve(void data.set(key, value)),
+    delete: (key: string) => Promise.resolve(void data.delete(key)),
+    keys: () => Promise.resolve([...data.keys()]),
+    clear: () => Promise.resolve(void data.clear()),
+    onChange: vi.fn((cb: (key: string, value: unknown) => void) => {
+      onChangeListeners.add(cb);
+      return Promise.resolve(() => onChangeListeners.delete(cb));
+    }),
+  };
+  return {
+    store,
+    load: vi.fn(() => Promise.resolve(store)),
+    emit: (key: string, value: unknown) => {
+      for (const cb of onChangeListeners) {
+        cb(key, value);
+      }
+    },
+  };
+}
+
+function createDriver(overrides: Partial<TauriStorageDriverOptions> = {}) {
+  const mock = createMockStore();
+  return {
+    mock,
+    driver: driver({
+      path: "store.json",
+      lib: mock as unknown as NonNullable<TauriStorageDriverOptions["lib"]>,
+      ...overrides,
+    }),
+  };
+}
+
+describe("drivers: tauri", () => {
+  testDriver({
+    driver: () => createDriver().driver,
+  });
+
+  testDriver({
+    driver: () => createDriver({ base: "app" }).driver,
+  });
+
+  it("watch: forwards scoped events, ignores unrelated keys, distinguishes remove", async () => {
+    const { mock, driver: d } = createDriver({ base: "app" });
+    const events: { event: string; key: string }[] = [];
+    const unwatch = await d.watch!((event, key) => {
+      events.push({ event, key });
+    });
+    expect(mock.load).toHaveBeenCalledWith("store.json", undefined);
+    mock.emit("app:foo", "value");
+    mock.emit("other:foo", "value");
+    mock.emit("app:bar", null);
+    expect(events).toMatchObject([
+      { event: "update", key: "foo" },
+      { event: "remove", key: "bar" },
+    ]);
+    await unwatch();
+  });
+});


### PR DESCRIPTION
## Summary
Add built-in driver for [Tauri Store Plugin](https://tauri.app/plugin/store) and driver documentation.

## Changes
- **Driver** `unstorage/drivers/tauri`: `path`, `base`, `options` (StoreOptions); implements hasItem, getItem, setItem, removeItem, getKeys, clear, watch
- **Docs**: `docs/2.drivers/tauri.md` + card in drivers index
- **Optional peer**: `@tauri-apps/plugin-store` ^2.0.0
- **Tests**: `test/drivers/tauri.test.ts` (mocked store)

Closes #748


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Tauri Store driver for data persistence in Tauri apps, with configurable store paths, optional namespaces, auto-save settings, and change-watch support.
  * Added dependency information for built-in drivers to help identify required integrations.

* **Documentation**
  * Added Tauri Store setup guidance, examples, options reference, and watch usage details.
  * Reorganized the drivers catalog into categorized tables with guidance for choosing a driver.

* **Tests**
  * Added coverage for Tauri Store operations, namespaces, change events, and cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->