### PR TITLE
fix(fs): ignore globs fail under dot-prefixed directories

### DIFF
--- a/src/drivers/fs.ts
+++ b/src/drivers/fs.ts
@@ -30,9 +30,12 @@ export default defineDriver((userOptions: FSStorageOptions = {}) => {
 
   const base = resolve(userOptions.base);
 
-  const ignore = anymatch(
-    userOptions.ignore || ["**/node_modules/**", "**/.git/**"]
-  );
+  const ignorePatterns = userOptions.ignore || [
+    "**/node_modules/**",
+    "**/.git/**",
+  ];
+  const ignore = (path: string) =>
+    anymatch(ignorePatterns, path, { dot: true });
 
   const r = (key: string) => {
     if (PATH_TRAVERSE_RE.test(key)) {

--- a/src/drivers/fs.ts
+++ b/src/drivers/fs.ts
@@ -30,12 +30,11 @@ export default defineDriver((userOptions: FSStorageOptions = {}) => {
 
   const base = resolve(userOptions.base);
 
-  const ignorePatterns = userOptions.ignore || [
-    "**/node_modules/**",
-    "**/.git/**",
-  ];
-  const ignore = (path: string) =>
-    anymatch(ignorePatterns, path, { dot: true });
+  const ignore = anymatch(
+    userOptions.ignore || ["**/node_modules/**", "**/.git/**"],
+    undefined,
+    { dot: true }
+  );
 
   const r = (key: string) => {
     if (PATH_TRAVERSE_RE.test(key)) {


### PR DESCRIPTION
## Summary

Backport fix for v1. The v2 alpha already resolved this by switching to `node:path`'s `matchesGlob` on relative paths.

- The fs driver's ignore matcher (defaulting to `**/node_modules/**` and `**/.git/**`) uses `anymatch`, which delegates to `picomatch`
- `picomatch` does not match `**` across dot-prefixed path segments by default (e.g. `.codex`, `.claude`)
- When the storage base is under a hidden directory, the ignore globs silently fail and chokidar watches thousands of `node_modules` files

This is particularly problematic when using git worktrees created by Claude Code or Codex, which place worktrees under `~/.claude/` or `~/.codex/` respectively. Any Nuxt project with DevTools enabled ends up watching all of `node_modules` because the `**/node_modules/**` ignore pattern can't match through the dot-prefixed ancestor.

The fix passes `{ dot: true }` to `anymatch` so `**` crosses dot-prefixed segments.

Fixes https://github.com/unjs/unstorage/issues/750
Related: https://github.com/nuxt/nuxt/issues/33300

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added generation of additional TypeScript type declaration formats.

* **Bug Fixes**
  * Updated core dependencies including file system watcher library to latest major version.

* **Documentation**
  * Added changelog entries for versions v1.17.4, v1.17.3, and v1.17.2.

* **Chores**
  * Removed automated publishing workflow.
  * Adjusted TypeScript export configuration.
  * Updated multiple development dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->