### PR TITLE
feat(s3): add sessionToken support for temporary AWS credentials

### DIFF
--- a/src/drivers/s3.ts
+++ b/src/drivers/s3.ts
@@ -42,6 +42,11 @@ export interface S3DriverOptions {
    * Enabled by default to speedup `clear()` operation. Set to `false` if provider is not implementing [DeleteObject](https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObjects.html).
    */
   bulkDelete?: boolean;
+
+  /**
+   * akin to AWS_SESSION_TOKEN if using temp credentials.
+   */
+  sessionToken?: string;
 }
 
 export interface S3ItemOptions {
@@ -84,6 +89,7 @@ const driver: DriverFactory<S3DriverOptions> = (options) => {
         service: "s3",
         accessKeyId: options.accessKeyId,
         secretAccessKey: options.secretAccessKey,
+        sessionToken: options.sessionToken,
         region: options.region,
       });
     }

--- a/src/tracing.ts
+++ b/src/tracing.ts
@@ -46,17 +46,21 @@ export interface TraceContext {
   };
 }
 
-type MaybeTracedStorage<T extends StorageValue> = Storage<T> & {
-  __traced?: boolean;
-};
+/**
+ * Runtime-only brand attached to wrapped storages so re-wrapping is a no-op.
+ * Kept off the public return type.
+ */
+type TracedBrand = { __traced?: boolean };
 
 /**
  * Wraps a storage instance with tracing capabilities.
  * All storage operations will emit tracing events through Node.js diagnostics channels.
  */
-export function withTracing<T extends StorageValue>(storage: MaybeTracedStorage<T>): Storage<T> {
+export function withTracing(storage: Storage<any>): Storage<StorageValue>;
+export function withTracing<T extends Storage<any>>(storage: T): T;
+export function withTracing<T extends Storage<any>>(storage: T): T {
   // Avoid wrapping already traced storages
-  if (storage.__traced) {
+  if ((storage as TracedBrand).__traced) {
     return storage;
   }
 
@@ -107,7 +111,10 @@ export function withTracing<T extends StorageValue>(storage: MaybeTracedStorage<
     return channel ? channel.tracePromise(exec, data) : exec();
   }
 
-  const tracedStorage: MaybeTracedStorage<T> = { ...storage, __traced: true };
+  const tracedStorage: T & TracedBrand = {
+    ...storage,
+    __traced: true,
+  };
 
   // Helper to get mount info for a key
   const getMountInfo = (key: string) => {
@@ -160,7 +167,9 @@ export function withTracing<T extends StorageValue>(storage: MaybeTracedStorage<
   }
 
   for (const operation in operations) {
-    tracedStorage[operation] = wrapOperation(operation as TracedOperation);
+    (tracedStorage as Record<TracedOperation, any>)[operation] = wrapOperation(
+      operation as TracedOperation,
+    );
   }
 
   // Wrap aliases


### PR DESCRIPTION
Adds sessionToken option to S3 driver for temporary AWS credentials. This is a pass-through to the sessionToken parameter already supported by aws4fetch library.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * S3 driver accepts an optional session token for temporary credentials, improving authentication flexibility.

* **Chores**
  * Tracing wrapper type signatures were refined for clearer typings and developer ergonomics; runtime tracing behavior remains unchanged.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unjs/unstorage/pull/777?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->