### PR TITLE
fix(prefixStorage): add regression test for keys() alias scoping

### DIFF
--- a/test/storage.test.ts
+++ b/test/storage.test.ts
@@ -274,4 +274,22 @@ describe("Regression", () => {
       { key: "key2", value: "value2" },
     ]);
   });
+
+  it("prefixStorage keys() alias returns prefix-scoped keys only (issue #654)", async () => {
+    const storage = createStorage();
+    const pStorage = prefixStorage(storage, "foo");
+
+    // Add items inside the prefix
+    await pStorage.setItem("x", "bar");
+    await pStorage.setItem("y", "baz");
+
+    // Add an item outside the prefix directly on the base storage
+    await storage.setItem("other:z", "qux");
+
+    // keys() must return only keys scoped to "foo", without the prefix
+    expect(await pStorage.keys()).toStrictEqual(["x", "y"]);
+
+    // keys() and getKeys() must be consistent
+    expect(await pStorage.keys()).toStrictEqual(await pStorage.getKeys());
+  });
 });


### PR DESCRIPTION
Closes #654

## Problem

`prefixStorage(storage, base)` wraps a storage object so that all operations are scoped to `base`. However, the `keys()` alias — which is copied from the original storage object via object spread — retained a closure over the original, unscoped `storage.getKeys`. This meant that `prefixStorage(s, "foo").keys()` returned **all global keys** (with prefix included and non-prefixed keys mixed in) instead of only the `foo:`-scoped keys with the prefix stripped.

## Root Cause

In `src/utils.ts`, `prefixStorage` builds `nsStorage` by spreading the original storage:

```ts
const nsStorage: Storage<T> = { ...storage };
```

The `keys` alias copied from the spread refers to the original `storage.getKeys` via its closure. While `nsStorage.getKeys` is subsequently overridden with a correctly scoped+stripping implementation, and then `nsStorage.keys = nsStorage.getKeys` re-points the alias to the fixed version, **there was no test covering this code path** — leaving the fix unverified and the issue unclosed.

## Fix

The one-liner fix `nsStorage.keys = nsStorage.getKeys` already exists in `src/utils.ts` (line 51). This PR adds a dedicated regression test that:

- stores keys **inside** the prefix (`foo:x`, `foo:y`) and **outside** it (`other:z`)
- asserts `pStorage.keys()` returns only `["x", "y"]` (scoped, prefix-stripped)
- asserts `pStorage.keys()` and `pStorage.getKeys()` are consistent

Without the fix the test fails with:

```
expected [ 'foo:x', 'foo:y', 'other:z' ] to strictly equal [ 'x', 'y' ]
```

With the fix it passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression test to ensure prefix-scoped storage key retrieval returns expected results without prefixes and remains consistent with related operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->