### PR TITLE
fix(s3): add prefix filtering and pagination to getKeys()

### DIFF
--- a/src/drivers/s3.ts
+++ b/src/drivers/s3.ts
@@ -127,12 +127,35 @@ const driver: DriverFactory<S3DriverOptions> = (options) => {
 
   // https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html
   const listObjects = async (prefix?: string) => {
-    const res = await awsFetch(baseURL).then((r) => r?.text());
-    if (!res) {
-      console.log("no list", prefix ? `${baseURL}?prefix=${prefix}` : baseURL);
-      return null;
-    }
-    return parseList(res);
+    const allKeys: string[] = [];
+    let continuationToken: string | undefined;
+
+    do {
+      const params = new URLSearchParams({ "list-type": "2" });
+      if (prefix) {
+        params.set("prefix", prefix);
+      }
+      if (continuationToken) {
+        params.set("continuation-token", continuationToken);
+      }
+
+      const listURL = `${baseURL}?${params.toString()}`;
+      const res = await awsFetch(listURL).then((r) => r?.text());
+      if (!res) {
+        return null;
+      }
+
+      const keys = parseList(res);
+      if (keys) {
+        allKeys.push(...keys);
+      }
+
+      // Check for more pages
+      const nextToken = res.match(/<NextContinuationToken>([\s\S]+?)<\/NextContinuationToken>/)?.[1];
+      continuationToken = nextToken || undefined;
+    } while (continuationToken);
+
+    return allKeys.length > 0 ? allKeys : null;
   };
 
   // https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html


### PR DESCRIPTION
## Problem

Two bugs in the S3 driver's `listObjects` function:

### 1. Prefix filtering not working

The `prefix` parameter was accepted but never passed to the S3 API. The function just logged it to console and made the request without it:

```ts
const res = await awsFetch(baseURL).then((r) => r?.text());  // no prefix!
console.log("no list", prefix ? `${baseURL}?prefix=${prefix}` : baseURL);  // just logging
```

This caused `getKeys('config')` to return ALL keys instead of filtered ones.

### 2. No pagination

S3's ListObjectsV2 returns max 1000 keys per response. The code ignored `NextContinuationToken`, causing `getKeys()` to silently return only the first 1000 keys.

## Fix

Build proper query params with `prefix` and `continuation-token`, and loop through all pages:

```ts
const listObjects = async (prefix?: string) => {
  const allKeys: string[] = [];
  let continuationToken: string | undefined;

  do {
    const params = new URLSearchParams({ "list-type": "2" });
    if (prefix) params.set("prefix", prefix);
    if (continuationToken) params.set("continuation-token", continuationToken);

    const res = await awsFetch(`${baseURL}?${params}`).then(r => r?.text());
    if (!res) return null;

    const keys = parseList(res);
    if (keys) allKeys.push(...keys);

    continuationToken = res.match(/<NextContinuationToken>(.+?)<\/NextContinuationToken>/)?.[1];
  } while (continuationToken);

  return allKeys.length > 0 ? allKeys : null;
};
```

Fixes #728


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved S3 object listing to return results across multiple pages instead of stopping after the first page.
  * Ensured empty listings are handled cleanly when no objects are found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->