### PR TITLE
fix(mongodb): close client connection on dispose

### DIFF
--- a/src/drivers/mongodb.ts
+++ b/src/drivers/mongodb.ts
@@ -5,7 +5,7 @@ import {
   type LibImport,
   type DriverDependencies,
 } from "./utils/index.ts";
-import type { Collection, MongoClientOptions } from "mongodb";
+import type { Collection, MongoClient, MongoClientOptions } from "mongodb";
 
 export interface MongoDbOptions {
   /**
@@ -45,6 +45,7 @@ const DRIVER_NAME = "mongodb";
 
 const driver: DriverFactory<MongoDbOptions, Promise<Collection>> = (opts) => {
   let collection: Promise<Collection> | undefined;
+  let client: MongoClient | undefined;
   const getMongoCollection = () =>
     (collection ??= (async () => {
       if (!opts.connectionString) {
@@ -56,8 +57,8 @@ const driver: DriverFactory<MongoDbOptions, Promise<Collection>> = (opts) => {
         opts.lib,
         () => import("mongodb"),
       );
-      const mongoClient = new MongoClient(opts.connectionString, opts.clientOptions);
-      const db = mongoClient.db(opts.databaseName || "unstorage");
+      client = new MongoClient(opts.connectionString, opts.clientOptions);
+      const db = client.db(opts.databaseName || "unstorage");
       return db.collection(opts.collectionName || "unstorage");
     })());
 
@@ -134,6 +135,15 @@ const driver: DriverFactory<MongoDbOptions, Promise<Collection>> = (opts) => {
     },
     async clear() {
       await (await getMongoCollection()).deleteMany({});
+    },
+    async dispose() {
+      if (collection) {
+        // Wait for any pending connection attempt to settle before closing it
+        await collection.catch(() => {});
+        collection = undefined;
+        await client?.close();
+        client = undefined;
+      }
     },
   };
 };

--- a/test/drivers/mongodb.test.ts
+++ b/test/drivers/mongodb.test.ts
@@ -2,6 +2,7 @@ import { afterAll, describe, expect, it } from "vitest";
 import driver from "../../src/drivers/mongodb.ts";
 import { testDriver } from "./utils.ts";
 import { MongoMemoryServer } from "mongodb-memory-server";
+import * as mongodb from "mongodb";
 import { promisify } from "node:util";
 
 describe("drivers: mongodb", async () => {
@@ -37,6 +38,47 @@ describe("drivers: mongodb", async () => {
         await ctx.storage.setItem("s1:a", "updated_test_data");
         const result = await ctx.storage.getMeta("s1:a");
         expect(result.mtime).not.toBe(result.birthtime);
+      });
+      it("should close the client on dispose", async () => {
+        const clients: TrackedMongoClient[] = [];
+        class TrackedMongoClient extends mongodb.MongoClient {
+          closeCalls = 0;
+          constructor(...args: ConstructorParameters<typeof mongodb.MongoClient>) {
+            super(...args);
+            clients.push(this);
+          }
+          override close(force?: boolean) {
+            this.closeCalls++;
+            return super.close(force);
+          }
+        }
+
+        const opts = {
+          connectionString,
+          databaseName: "test",
+          collectionName: "dispose",
+          lib: { ...mongodb, MongoClient: TrackedMongoClient },
+        };
+
+        // Disposing before connecting is a no-op
+        await driver(opts).dispose!();
+        expect(clients.length).toBe(0);
+
+        const mongoDriver = driver(opts);
+        await mongoDriver.setItem!("a", "test_data", {});
+        expect(clients.length).toBe(1);
+
+        await mongoDriver.dispose!();
+        expect(clients[0]!.closeCalls).toBe(1);
+
+        // Disposing twice is a no-op
+        await mongoDriver.dispose!();
+        expect(clients[0]!.closeCalls).toBe(1);
+
+        // A new client is created if the driver is used again
+        expect(await mongoDriver.getItem!("a", {})).toBe("test_data");
+        expect(clients.length).toBe(2);
+        await mongoDriver.dispose!();
       });
     },
   });


### PR DESCRIPTION
The mongodb driver creates a `MongoClient` on first access but never closes it, so the connection pool stays open after `storage.dispose()`. The `redis`, `deno-kv` and `db0` (#693) drivers already close their connection on dispose; this brings mongodb in line.

It keeps a reference to the client and closes it in `dispose()`. The optional chain covers the case where dispose runs before any connection was opened, and `MongoClient.close()` is safe to call more than once, so the `driver.dispose()` then `storage.dispose()` path in the test harness is fine.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MongoDB connection cleanup so active connections close reliably when no longer needed.
  * Added safe cleanup handling that can be called repeatedly without errors.
  * Ensured the database connection can be established again after cleanup, improving reliability for repeated application use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->