### PR TITLE
fix: prefixStorage should strip base and emit only related event with…

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -50,6 +50,13 @@ export function prefixStorage<T extends StorageValue>(
 
   nsStorage.keys = nsStorage.getKeys;
 
+  nsStorage.watch = (callback) =>
+    storage.watch((event, key) => {
+      if (key.startsWith(base)) {
+        return callback(event, key.slice(base.length));
+      }
+    });
+
   nsStorage.getItems = async <U extends T>(
     items: (string | { key: string; options?: TransactionOptions })[],
     commonOptions?: TransactionOptions,

--- a/test/storage.test.ts
+++ b/test/storage.test.ts
@@ -149,6 +149,23 @@ describe("utils", () => {
     expect(await mntStorage.getKeys("foo")).toStrictEqual(["foo:x", "foo:y"]);
   });
 
+  it("prefixStorage watch strips base from callback key", async () => {
+    const storage = createStorage();
+    const pStorage = prefixStorage(storage, "foo");
+    const onChange = vi.fn();
+
+    await pStorage.watch(onChange);
+    await pStorage.setItem("x", "bar");
+    await storage.setItem("foo:y", "baz");
+    await storage.setItem("bar:x", "ignored");
+    await pStorage.removeItem("x");
+
+    expect(onChange).toHaveBeenCalledWith("update", "x");
+    expect(onChange).toHaveBeenCalledWith("update", "y");
+    expect(onChange).toHaveBeenCalledWith("remove", "x");
+    expect(onChange).toHaveBeenCalledTimes(3);
+  });
+
   it("stringify", () => {
     const storage = createStorage();
     expect(async () => await storage.setItem("foo", [])).not.toThrow();


### PR DESCRIPTION
I noticed that when using `useStorage('base')`, the `.watch` will emit the events not related to the base itself and also send the full key, making it inconsistent with the other overwritten keys.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added change-watching support for prefixed storage, with notifications scoped to matching keys and delivered using the unprefixed key name.
* **Tests**
  * Added coverage to verify prefixed storage watch events correctly report updates and removals with the prefix removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->