### PR TITLE
fix(storage): apply clear(base) to keys on the parent mount

### DIFF
--- a/src/storage.ts
+++ b/src/storage.ts
@@ -355,19 +355,33 @@ export function createStorage<T extends StorageValue>(
     // Utils
     async clear(base, opts = {}) {
       base = normalizeBaseKey(base);
-      await Promise.all(
-        getMounts(base, false).map(async (m) => {
-          if (m.driver.clear) {
-            return asyncCall(m.driver.clear, m.relativeBase, opts);
-          }
-          // Fallback to remove all keys if clear not implemented
-          if (m.driver.removeItem) {
-            const keys = await m.driver.getKeys(m.relativeBase || "", opts);
-            return Promise.all(keys.map((key) => m.driver.removeItem!(key, opts)));
-          }
-          // Readonly
-        }),
-      );
+      // includeParent so a prefix on the root mount is in scope (issue #801).
+      // Nested mounts are still processed first and then masked, so a parent
+      // mount is not asked to delete keys that belong to a child driver.
+      const mounts = getMounts(base, true);
+      let maskedMounts: string[] = [];
+      for (const mount of mounts) {
+        const relativeBase = mount.relativeBase || "";
+        if (mount.driver.clear && !relativeBase) {
+          await asyncCall(mount.driver.clear, relativeBase, opts);
+        } else if (mount.driver.removeItem) {
+          const keys = await asyncCall(mount.driver.getKeys, relativeBase, opts);
+          await Promise.all(
+            keys
+              .filter((key) => {
+                const fullKey = mount.mountpoint + normalizeKey(key);
+                return (
+                  !maskedMounts.some((p) => fullKey.startsWith(p)) && filterKeyByBase(fullKey, base)
+                );
+              })
+              .map((key) => mount.driver.removeItem!(key, opts)),
+          );
+        }
+        maskedMounts = [
+          mount.mountpoint,
+          ...maskedMounts.filter((p) => !p.startsWith(mount.mountpoint)),
+        ];
+      }
     },
     async dispose() {
       await Promise.all(Object.values(context.mounts).map((driver) => dispose(driver)));

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -370,9 +370,14 @@ export function createStorage<T extends StorageValue>(
             keys
               .filter((key) => {
                 const fullKey = mount.mountpoint + normalizeKey(key);
-                return (
-                  !maskedMounts.some((p) => fullKey.startsWith(p)) && filterKeyByBase(fullKey, base)
-                );
+                if (maskedMounts.some((p) => fullKey.startsWith(p))) {
+                  return false;
+                }
+                if (filterKeyByBase(fullKey, base)) {
+                  return true;
+                }
+                // Companion metadata is stored as `${key}$` and excluded by filterKeyByBase.
+                return fullKey.endsWith("$") && filterKeyByBase(fullKey.slice(0, -1), base);
               })
               .map((key) => mount.driver.removeItem!(key, opts)),
           );

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -362,7 +362,12 @@ export function createStorage<T extends StorageValue>(
       let maskedMounts: string[] = [];
       for (const mount of mounts) {
         const relativeBase = mount.relativeBase || "";
-        if (mount.driver.clear && !relativeBase) {
+        const hasMaskedChild = maskedMounts.some((maskedMount) =>
+          maskedMount.startsWith(mount.mountpoint),
+        );
+        // driver.clear() wipes the whole mount. Skip it when a nested child
+        // mount is masking keys that should survive until unmount.
+        if (mount.driver.clear && !relativeBase && !hasMaskedChild) {
           await asyncCall(mount.driver.clear, relativeBase, opts);
         } else if (mount.driver.removeItem) {
           const keys = await asyncCall(mount.driver.getKeys, relativeBase, opts);

--- a/test/storage.test.ts
+++ b/test/storage.test.ts
@@ -138,6 +138,17 @@ describe("storage", () => {
     expect(await storage.getItem("bar:b")).toBe(2);
   });
 
+  it("clear(base) also removes companion metadata for matching keys", async () => {
+    const storage = createStorage();
+    await storage.setItem("foo:a", 1);
+    await storage.setMeta("foo:a", { note: "x" });
+    await storage.setItem("bar:b", 2);
+    await storage.setMeta("bar:b", { note: "y" });
+    await storage.clear("foo");
+    expect(await storage.getMeta("foo:a")).toEqual({});
+    expect(await storage.getMeta("bar:b")).toEqual({ note: "y" });
+  });
+
   it("clear(base) does not wipe keys hidden under a nested mount", async () => {
     const storage = createStorage();
     await storage.setItem("mnt:hidden", "keep");

--- a/test/storage.test.ts
+++ b/test/storage.test.ts
@@ -127,6 +127,27 @@ describe("storage", () => {
     expect(await storage.getKeys()).toMatchObject(initialKeys);
     expect(await storage.getItem("/mnt/test.txt")).toBe("v1");
   });
+
+  it("clear(base) removes matching keys on the root mount (issue #801)", async () => {
+    const storage = createStorage();
+    await storage.setItem("foo:a", 1);
+    await storage.setItem("bar:b", 2);
+    await storage.clear("foo");
+    expect(await storage.getKeys()).toEqual(["bar:b"]);
+    expect(await storage.getItem("foo:a")).toBe(null);
+    expect(await storage.getItem("bar:b")).toBe(2);
+  });
+
+  it("clear(base) does not wipe keys hidden under a nested mount", async () => {
+    const storage = createStorage();
+    await storage.setItem("mnt:hidden", "keep");
+    storage.mount("/mnt", memory());
+    await storage.setItem("mnt:visible", "drop");
+    await storage.clear("/mnt");
+    expect(await storage.getItem("mnt:visible")).toBe(null);
+    await storage.unmount("/mnt");
+    expect(await storage.getItem("mnt:hidden")).toBe("keep");
+  });
 });
 
 describe("utils", () => {
@@ -292,5 +313,15 @@ describe("Regression", () => {
       { key: "key1", value: "value1" },
       { key: "key2", value: "value2" },
     ]);
+  });
+
+  it("prefixStorage clear only removes the prefixed subset (issue #801)", async () => {
+    const storage = createStorage();
+    await storage.setItem("users:1", "a");
+    await storage.setItem("orders:1", "b");
+    const users = prefixStorage(storage, "users");
+    await users.clear();
+    expect(await storage.getItem("users:1")).toBe(null);
+    expect(await storage.getItem("orders:1")).toBe("b");
   });
 });

--- a/test/storage.test.ts
+++ b/test/storage.test.ts
@@ -159,6 +159,23 @@ describe("storage", () => {
     await storage.unmount("/mnt");
     expect(await storage.getItem("mnt:hidden")).toBe("keep");
   });
+
+  it("clear(base) does not wipe parent-driver keys hidden by a nested child mount", async () => {
+    const storage = createStorage();
+    storage.mount("/mnt", memory());
+    await storage.setItem("/mnt/keep", "keep");
+    await storage.setItem("/mnt/foo/hidden", "hidden");
+    storage.mount("/mnt/foo", memory());
+    await storage.setItem("/mnt/foo/child", "child");
+
+    await storage.clear("/mnt");
+
+    expect(await storage.getItem("/mnt/keep")).toBe(null);
+    expect(await storage.getItem("/mnt/foo/child")).toBe(null);
+
+    await storage.unmount("/mnt/foo");
+    expect(await storage.getItem("/mnt/foo/hidden")).toBe("hidden");
+  });
 });
 
 describe("utils", () => {


### PR DESCRIPTION
## Summary

\`storage.clear(base)\` used \`getMounts(base, false)\`, which excludes the parent mount. With only a root driver, \`getMounts(\"foo:\", false)\` is empty, so nothing is deleted:

\`\`\`ts
const storage = createStorage()
await storage.setItem('foo:a', 1)
await storage.setItem('bar:b', 2)
await storage.clear('foo')
await storage.getKeys() // was ['foo:a', 'bar:b']
\`\`\`

The same path is what \`prefixStorage(storage, 'foo').clear()\` uses.

## Fix

Use \`getMounts(base, true)\` like \`getKeys\`. Call \`driver.clear()\` only when the whole mount is in scope. For a prefix on a parent mount, list keys, mask nested mounts, and \`removeItem\` the ones under \`base\`. That also avoids asking drivers that ignore their \`base\` argument (MongoDB, Azure blob/table/cosmos) to wipe the entire store.

Fixes #801 (the \`clear(base)\` no-op). Related to #802.

## Test plan

- [x] Fail-then-pass: \`storage.clear('foo')\` left \`foo:a\` in place; after the fix only \`bar:b\` remains
- [x] \`prefixStorage(storage, 'users').clear()\` removes \`users:*\` and keeps \`orders:*\`
- [x] \`clear('/mnt')\` still does not delete keys hidden under a nested mount (existing mount-override test)
- [x] \`pnpm vitest run test/storage.test.ts test/drivers/fs.test.ts\`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved storage clearing so it removes only keys within the selected scope.
  * Related metadata is now cleared with its matching key, while metadata for other keys is preserved.
  * Preserved hidden keys managed by nested or masked storage mounts.
  * Prefixed storage clearing remains limited to the configured prefix.

* **Tests**
  * Added regression coverage for root-level, nested, metadata, and prefixed storage clearing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->