### PR TITLE
fix(azure-cosmos): dispose the cosmos client on dispose

### DIFF
--- a/src/drivers/azure-cosmos.ts
+++ b/src/drivers/azure-cosmos.ts
@@ -6,7 +6,7 @@ import {
   type DriverDependencies,
 } from "./utils/index.ts";
 import { type AzureIdentityOptions, createDefaultAzureCredential } from "./utils/azure.ts";
-import type { Container } from "@azure/cosmos";
+import type { Container, CosmosClient } from "@azure/cosmos";
 
 export interface AzureCosmosOptions extends AzureIdentityOptions {
   /**
@@ -64,6 +64,7 @@ export interface AzureCosmosItem {
 
 const driver: DriverFactory<AzureCosmosOptions, Promise<Container>> = (opts) => {
   let client: Promise<Container> | undefined;
+  let cosmosClient: CosmosClient | undefined;
   const getCosmosClient = () =>
     (client ??= (async () => {
       if (!opts.endpoint) {
@@ -75,7 +76,7 @@ const driver: DriverFactory<AzureCosmosOptions, Promise<Container>> = (opts) => 
         opts.lib,
         () => import("@azure/cosmos"),
       );
-      const cosmosClient = opts.accountKey
+      cosmosClient = opts.accountKey
         ? new CosmosClient({ endpoint: opts.endpoint, key: opts.accountKey })
         : new CosmosClient({
             endpoint: opts.endpoint,
@@ -141,6 +142,15 @@ const driver: DriverFactory<AzureCosmosOptions, Promise<Container>> = (opts) => 
         )
           .item(item.id)
           .delete<AzureCosmosItem>({ consistencyLevel: "Session" });
+      }
+    },
+    async dispose() {
+      if (client) {
+        // Wait for any pending connection attempt to settle before disposing it
+        await client.catch(() => {});
+        client = undefined;
+        cosmosClient?.dispose();
+        cosmosClient = undefined;
       }
     },
   };

--- a/test/drivers/azure-cosmos.test.ts
+++ b/test/drivers/azure-cosmos.test.ts
@@ -1,4 +1,5 @@
-import { describe } from "vitest";
+import { describe, expect, it } from "vitest";
+import * as cosmos from "@azure/cosmos";
 import driver from "../../src/drivers/azure-cosmos.ts";
 import { testDriver } from "./utils.ts";
 
@@ -8,5 +9,60 @@ describe.skip("drivers: azure-cosmos", () => {
       endpoint: "COSMOS_DB_ENDPOINT",
       accountKey: "COSMOS_DB_KEY",
     }),
+  });
+});
+
+describe("drivers: azure-cosmos (fake)", () => {
+  it("should dispose the client on dispose", async () => {
+    const clients: FakeCosmosClient[] = [];
+
+    // Minimal fake of `CosmosClient`, just enough surface for the driver to resolve
+    // a container without reaching a real Cosmos DB account.
+    class FakeCosmosClient {
+      disposeCalls = 0;
+      databases = {
+        createIfNotExists: async () => ({
+          database: {
+            containers: {
+              createIfNotExists: async () => ({
+                container: { item: () => ({ read: async () => ({}) }) },
+              }),
+            },
+          },
+        }),
+      };
+      constructor() {
+        clients.push(this);
+      }
+      dispose() {
+        this.disposeCalls++;
+      }
+    }
+
+    const opts = {
+      endpoint: "https://localhost:8081",
+      accountKey: "test",
+      lib: { ...cosmos, CosmosClient: FakeCosmosClient as any },
+    };
+
+    // Disposing before connecting is a no-op
+    await driver(opts).dispose!();
+    expect(clients.length).toBe(0);
+
+    const cosmosDriver = driver(opts);
+    expect(await cosmosDriver.getItem!("a", {})).toBe(null);
+    expect(clients.length).toBe(1);
+
+    await cosmosDriver.dispose!();
+    expect(clients[0]!.disposeCalls).toBe(1);
+
+    // Disposing twice is a no-op
+    await cosmosDriver.dispose!();
+    expect(clients[0]!.disposeCalls).toBe(1);
+
+    // A new client is created if the driver is used again
+    expect(await cosmosDriver.getItem!("a", {})).toBe(null);
+    expect(clients.length).toBe(2);
+    await cosmosDriver.dispose!();
   });
 });


### PR DESCRIPTION
The azure-cosmos driver only kept the resolved `Container` promise around, so the `CosmosClient` behind it was unreachable once the factory returned. `CosmosClient` starts a background endpoint refresher on construction and its own docs say to call `client.dispose()` when you are done with it, so `storage.dispose()` left that timer running and could keep a Node process alive.

The driver now holds on to the client and disposes it in its own `dispose()`, the same way #792 did for mongodb. The container promise is cleared too, so the driver reconnects if it gets used again.

Fixes #809

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a disposal method for the Azure Cosmos connection, allowing resources to be cleanly released and the driver to be reused.
* **Bug Fixes**
  * Improved connection lifecycle handling, including cleanup during pending initialization and repeated disposal.
* **Tests**
  * Added coverage for disposal before connection, after connection, repeated disposal, and subsequent client recreation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->