### PR TITLE
fix(azure-cosmos): dispose the CosmosClient on driver dispose

### DIFF
--- a/src/drivers/azure-cosmos.ts
+++ b/src/drivers/azure-cosmos.ts
@@ -6,7 +6,7 @@ import {
   type DriverDependencies,
 } from "./utils/index.ts";
 import { type AzureIdentityOptions, createDefaultAzureCredential } from "./utils/azure.ts";
-import type { Container } from "@azure/cosmos";
+import type { Container, CosmosClient as CosmosClientType } from "@azure/cosmos";
 
 export interface AzureCosmosOptions extends AzureIdentityOptions {
   /**
@@ -64,6 +64,7 @@ export interface AzureCosmosItem {
 
 const driver: DriverFactory<AzureCosmosOptions, Promise<Container>> = (opts) => {
   let client: Promise<Container> | undefined;
+  let cosmosClient: CosmosClientType | undefined;
   const getCosmosClient = () =>
     (client ??= (async () => {
       if (!opts.endpoint) {
@@ -75,7 +76,7 @@ const driver: DriverFactory<AzureCosmosOptions, Promise<Container>> = (opts) => 
         opts.lib,
         () => import("@azure/cosmos"),
       );
-      const cosmosClient = opts.accountKey
+      cosmosClient = opts.accountKey
         ? new CosmosClient({ endpoint: opts.endpoint, key: opts.accountKey })
         : new CosmosClient({
             endpoint: opts.endpoint,
@@ -141,6 +142,16 @@ const driver: DriverFactory<AzureCosmosOptions, Promise<Container>> = (opts) => 
         )
           .item(item.id)
           .delete<AzureCosmosItem>({ consistencyLevel: "Session" });
+      }
+    },
+    async dispose() {
+      if (client) {
+        // Wait for any pending connection attempt to settle before disposing it
+        await client.catch(() => {});
+        client = undefined;
+        // Clears the background endpoint refresher kept alive by the client
+        cosmosClient?.dispose();
+        cosmosClient = undefined;
       }
     },
   };

--- a/test/drivers/azure-cosmos.test.ts
+++ b/test/drivers/azure-cosmos.test.ts
@@ -46,7 +46,11 @@ describe("drivers: azure-cosmos (dispose)", () => {
 
   it("disposes the CosmosClient", async () => {
     const { clients, lib } = createFakeLib();
-    const opts = { endpoint: "https://example.documents.azure.com:443/", accountKey: "key", lib };
+    const opts = {
+      endpoint: "https://example.documents.azure.com:443/",
+      accountKey: "key",
+      lib,
+    };
 
     // Disposing before connecting is a no-op
     await driver(opts).dispose!();
@@ -68,5 +72,35 @@ describe("drivers: azure-cosmos (dispose)", () => {
     expect(clients.length).toBe(2);
     await cosmosDriver.dispose!();
     expect(clients[1]!.disposeCalls).toBe(1);
+  });
+
+  it("disposes a client created while initialization is pending", async () => {
+    const { clients, lib } = createFakeLib();
+    let releaseLib!: () => void;
+    const libLoaded = new Promise<void>((resolve) => {
+      releaseLib = resolve;
+    });
+
+    const cosmosDriver = driver({
+      endpoint: "https://example.documents.azure.com:443/",
+      accountKey: "key",
+      lib: async () => {
+        await libLoaded;
+        return lib;
+      },
+    });
+
+    // Start initialization, then dispose while it is still in-flight
+    const pending = cosmosDriver.setItem!("a", "test_data", {});
+    expect(clients.length).toBe(0);
+    const disposed = cosmosDriver.dispose!();
+
+    releaseLib();
+    await pending;
+    await disposed;
+
+    // The client created by the in-flight initialization is disposed exactly once
+    expect(clients.length).toBe(1);
+    expect(clients[0]!.disposeCalls).toBe(1);
   });
 });

--- a/test/drivers/azure-cosmos.test.ts
+++ b/test/drivers/azure-cosmos.test.ts
@@ -1,4 +1,4 @@
-import { describe } from "vitest";
+import { describe, expect, it } from "vitest";
 import driver from "../../src/drivers/azure-cosmos.ts";
 import { testDriver } from "./utils.ts";
 
@@ -8,5 +8,65 @@ describe.skip("drivers: azure-cosmos", () => {
       endpoint: "COSMOS_DB_ENDPOINT",
       accountKey: "COSMOS_DB_KEY",
     }),
+  });
+});
+
+describe("drivers: azure-cosmos (dispose)", () => {
+  // Minimal `@azure/cosmos` stand-in: the driver only needs to reach a container.
+  function createFakeLib() {
+    const clients: { disposeCalls: number }[] = [];
+    const container = {
+      item: () => ({
+        read: async () => ({ resource: undefined }),
+      }),
+      items: {
+        upsert: async () => {},
+      },
+    };
+    class CosmosClient {
+      disposeCalls = 0;
+      databases = {
+        createIfNotExists: async () => ({
+          database: {
+            containers: {
+              createIfNotExists: async () => ({ container }),
+            },
+          },
+        }),
+      };
+      constructor() {
+        clients.push(this);
+      }
+      dispose() {
+        this.disposeCalls++;
+      }
+    }
+    return { clients, lib: { CosmosClient } as any };
+  }
+
+  it("disposes the CosmosClient", async () => {
+    const { clients, lib } = createFakeLib();
+    const opts = { endpoint: "https://example.documents.azure.com:443/", accountKey: "key", lib };
+
+    // Disposing before connecting is a no-op
+    await driver(opts).dispose!();
+    expect(clients.length).toBe(0);
+
+    const cosmosDriver = driver(opts);
+    await cosmosDriver.setItem!("a", "test_data", {});
+    expect(clients.length).toBe(1);
+
+    await cosmosDriver.dispose!();
+    expect(clients[0]!.disposeCalls).toBe(1);
+
+    // Disposing twice is a no-op
+    await cosmosDriver.dispose!();
+    expect(clients[0]!.disposeCalls).toBe(1);
+
+    // A new client is created if the driver is used again
+    await cosmosDriver.hasItem!("a", {});
+    expect(clients.length).toBe(2);
+    await cosmosDriver.dispose!();
+    expect(clients[1]!.disposeCalls).toBe(1);
   });
 });


### PR DESCRIPTION
Closes #809

### Problem

`azure-cosmos.ts` only kept the resolved `Promise<Container>`. The `CosmosClient` created inside `getCosmosClient()` never escaped that closure, and the driver exposed no `dispose()` at all.

`@azure/cosmos` starts a background endpoint refresher on construction, and its own type doc says:

> Clears background endpoint refresher. Use `client.dispose()` when destroying the CosmosClient within another process.

So `storage.dispose()` on a Cosmos-backed storage left that timer running — it leaks and can keep a Node process alive. The other drivers with external connections (`db0`, `deno-kv`, `mongodb`, `redis`) all implement `dispose()`; azure-cosmos was missed in the pass that added it to mongodb (#792).

### Change

- Hold the `CosmosClient` in a driver-scoped variable alongside the container promise.
- Add `dispose()`, mirroring the mongodb driver: await the in-flight connection so a pending attempt can't resurrect state, clear the cached promise, then call `client.dispose()`.

Disposing before ever connecting, and disposing twice, are both no-ops; using the driver again after dispose lazily creates a fresh client, same as mongodb.

### Validation

- `vitest run test/drivers/azure-cosmos.test.ts` → 1 passed (the pre-existing live-service suite stays `describe.skip`).
- The new test fails on `main` with `default(...).dispose is not a function`, so it pins the regression.
- The test drives the driver through a minimal `lib` stub, so it needs no Cosmos account and runs in CI.
- `oxlint` and `oxfmt --check` clean on both touched files.
- `tsc --noEmit --skipLibCheck` reports no new errors (the existing `unstorage/drivers/*` self-import errors are present on `main` too, they need a build first).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Azure Cosmos connection cleanup and resource disposal.
  * Prevented stale connections from being reused after disposal.
  * Ensured disposal is safe before a connection is established.
  * Added reliable cleanup when disposal occurs during connection initialization.
  * Enabled fresh connections to be created when the driver is reused.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->