### PR TITLE
docs: fix dead snapshots link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Unstorage provides an async Key-Value storage API with conventional features lik
 - Tree-shakable utils and tiny core
 - Auto JSON value serialization and deserialization
 - Binary and raw value support
-- State [snapshots](https://unstorage.unjs.io/getting-started/utils#snapshots) and hydration
+- State [snapshots](https://unstorage.unjs.io/guide/utils#snapshots) and hydration
 - Storage watcher
 - HTTP Storage with [built-in server](https://unstorage.unjs.io/guide/http-server)
 


### PR DESCRIPTION
The feature list links snapshots to `unstorage.unjs.io/getting-started/utils#snapshots`, which 404s. The page lives at `/guide/utils`, and the `#snapshots` heading is there.

```
$ curl -sIL -o /dev/null -w '%{http_code}\n' https://unstorage.unjs.io/getting-started/utils
404
$ curl -sIL -o /dev/null -w '%{http_code}\n' https://unstorage.unjs.io/guide/utils
200
```

One line, readme only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README link for state snapshots and hydration to point to the correct guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->