### PR TITLE
fix(localstorage): report empty string writes as updates

### DIFF
--- a/src/drivers/localstorage.ts
+++ b/src/drivers/localstorage.ts
@@ -82,7 +82,7 @@ const driver: DriverFactory<LocalStorageOptions, Storage> = (opts = {}) => {
       }
       _storageListener = (ev: StorageEvent) => {
         if (ev.key) {
-          callback(ev.newValue ? "update" : "remove", ev.key);
+          callback(ev.newValue === null ? "remove" : "update", ev.key);
         }
       };
       opts.window.addEventListener("storage", _storageListener);

--- a/test/drivers/localstorage.test.ts
+++ b/test/drivers/localstorage.test.ts
@@ -39,6 +39,22 @@ describe("drivers: localstorage", () => {
 
         expect(watcher).toHaveBeenCalledWith("update", "s1:random_file");
       });
+      it("reports empty string writes as updates", async () => {
+        const watcher = vi.fn();
+        const unwatch = await ctx.driver.watch!(watcher);
+
+        const ev = new jsdom.window.StorageEvent("storage", {
+          key: "test:empty",
+          newValue: "",
+          oldValue: null,
+          storageArea: jsdom.window.localStorage,
+          url: jsdom.window.location.href,
+        });
+        jsdom.window.dispatchEvent(ev);
+
+        await unwatch();
+        expect(watcher).toHaveBeenCalledWith("update", "test:empty");
+      });
       it("unwatch localstorage", async () => {
         const watcher = vi.fn();
         const unwatch = await ctx.storage.watch(watcher);


### PR DESCRIPTION
## Problem

The localStorage driver's storage-event watcher classified any event with a falsy newValue as a removal. A valid write of the empty string was therefore reported as remove instead of update.

## Fix

Classify only newValue === null as a removal. Empty strings and all other string values are writes and are reported as updates.

## Tests

- pnpm exec vitest run test/drivers/localstorage.test.ts -t "reports empty string writes as updates" - failed before the fix as expected; passed after the fix
- pnpm test - passed; 549 tests, 223 skipped, no type errors
- pnpm build - passed
- pnpm test:types - passed
- pnpm vitest --coverage - passed; 549 tests, 223 skipped
- pnpm lint - passed; existing S3 unused-parameter warning remains
- git diff HEAD^ HEAD --check - passed

## Compatibility

Null removals and non-empty updates retain their behavior. The change only corrects the event classification for the valid empty-string value.

## Related issue

Independent current-branch reproduction. No matching issue or pull request was found in the final collision search.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected local storage event handling so empty-string and other falsy values are recognized as updates.
  * Removal events are now identified accurately when stored data is deleted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->