### PR TITLE
fix(storage): emit watch events for setItems

### DIFF
--- a/src/storage.ts
+++ b/src/storage.ts
@@ -221,7 +221,7 @@ export function createStorage<T extends StorageValue>(
     async setItems(items, commonOptions) {
       await runBatch(items, commonOptions, async (batch) => {
         if (batch.driver.setItems) {
-          return asyncCall(
+          await asyncCall(
             batch.driver.setItems,
             batch.items.map((item) => ({
               key: item.relativeKey,
@@ -230,20 +230,25 @@ export function createStorage<T extends StorageValue>(
             })),
             commonOptions,
           );
+        } else if (batch.driver.setItem) {
+          await Promise.all(
+            batch.items.map((item) => {
+              return asyncCall(
+                batch.driver.setItem!,
+                item.relativeKey,
+                stringify(item.value),
+                item.options,
+              );
+            }),
+          );
+        } else {
+          return; // Readonly
         }
-        if (!batch.driver.setItem) {
-          return;
+        if (!batch.driver.watch) {
+          for (const item of batch.items) {
+            onChange("update", item.key);
+          }
         }
-        await Promise.all(
-          batch.items.map((item) => {
-            return asyncCall(
-              batch.driver.setItem!,
-              item.relativeKey,
-              stringify(item.value),
-              item.options,
-            );
-          }),
-        );
       });
     },
     async setItemRaw(key, value, opts = {}) {

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -231,7 +231,9 @@ export function createStorage<T extends StorageValue>(
             commonOptions,
           );
         } else if (batch.driver.setItem) {
-          await Promise.all(
+          // A rejected sibling write must not suppress the events for the
+          // writes that did land: those values are in the driver either way.
+          const results = await Promise.allSettled(
             batch.items.map((item) => {
               return asyncCall(
                 batch.driver.setItem!,
@@ -241,6 +243,18 @@ export function createStorage<T extends StorageValue>(
               );
             }),
           );
+          if (!batch.driver.watch) {
+            for (const [index, item] of batch.items.entries()) {
+              if (results[index]?.status === "fulfilled") {
+                onChange("update", item.key);
+              }
+            }
+          }
+          const rejected = results.find((r) => r.status === "rejected");
+          if (rejected) {
+            throw (rejected as PromiseRejectedResult).reason;
+          }
+          return;
         } else {
           return; // Readonly
         }

--- a/test/storage.test.ts
+++ b/test/storage.test.ts
@@ -74,6 +74,42 @@ describe("storage", () => {
     expect(onChange).toHaveBeenCalledTimes(2);
   });
 
+  it("watch: setItems", async () => {
+    const onChange = vi.fn();
+    const storage = createStorage().mount("/mnt", memory());
+    await storage.watch(onChange);
+    await storage.setItems([
+      { key: "mnt:etc:conf", value: "test" },
+      { key: "mnt:data:foo", value: "123" },
+    ]);
+    expect(onChange).toHaveBeenCalledWith("update", "mnt:etc:conf");
+    expect(onChange).toHaveBeenCalledWith("update", "mnt:data:foo");
+    expect(onChange).toHaveBeenCalledTimes(2);
+  });
+
+  it("watch: setItems with a driver implementing setItems", async () => {
+    const onChange = vi.fn();
+    const store = new Map<string, any>();
+    const storage = createStorage().mount("/mnt", {
+      name: "batch-memory",
+      hasItem: (key) => store.has(key),
+      getItem: (key) => store.get(key) ?? null,
+      getKeys: () => [...store.keys()],
+      setItem: (key, value) => {
+        store.set(key, value);
+      },
+      setItems: (items) => {
+        for (const item of items) {
+          store.set(item.key, item.value);
+        }
+      },
+    });
+    await storage.watch(onChange);
+    await storage.setItems([{ key: "mnt:data:foo", value: 123 }]);
+    expect(onChange).toHaveBeenCalledWith("update", "mnt:data:foo");
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
   it("unwatch return", async () => {
     const onChange = vi.fn();
     const storage = createStorage().mount("/mnt", memory());

--- a/test/storage.test.ts
+++ b/test/storage.test.ts
@@ -90,24 +90,57 @@ describe("storage", () => {
   it("watch: setItems with a driver implementing setItems", async () => {
     const onChange = vi.fn();
     const store = new Map<string, any>();
+    const setItems = vi.fn((items: { key: string; value: any }[]) => {
+      for (const item of items) {
+        store.set(item.key, item.value);
+      }
+    });
     const storage = createStorage().mount("/mnt", {
       name: "batch-memory",
       hasItem: (key) => store.has(key),
       getItem: (key) => store.get(key) ?? null,
       getKeys: () => [...store.keys()],
-      setItem: (key, value) => {
-        store.set(key, value);
+      // Present so the driver is not read-only, and fatal so a regression
+      // that routes a batch through the per-item path cannot pass by writing
+      // the same value and emitting the same event.
+      setItem: () => {
+        throw new Error("setItem must not be used when setItems exists");
       },
-      setItems: (items) => {
-        for (const item of items) {
-          store.set(item.key, item.value);
-        }
-      },
+      setItems,
     });
     await storage.watch(onChange);
     await storage.setItems([{ key: "mnt:data:foo", value: 123 }]);
+    expect(setItems).toHaveBeenCalledTimes(1);
+    expect(store.get("data:foo")).toBe("123");
     expect(onChange).toHaveBeenCalledWith("update", "mnt:data:foo");
     expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it("watch: setItems emits for writes that landed when a sibling write fails", async () => {
+    const onChange = vi.fn();
+    const store = new Map<string, any>();
+    const storage = createStorage().mount("/mnt", {
+      name: "per-item-memory",
+      hasItem: (key) => store.has(key),
+      getItem: (key) => store.get(key) ?? null,
+      getKeys: () => [...store.keys()],
+      setItem: (key, value) => {
+        if (key === "data:bad") {
+          throw new Error("nope");
+        }
+        store.set(key, value);
+      },
+    });
+    await storage.watch(onChange);
+    await expect(
+      storage.setItems([
+        { key: "mnt:data:good", value: 1 },
+        { key: "mnt:data:bad", value: 2 },
+      ]),
+    ).rejects.toThrow("nope");
+    expect(store.get("data:good")).toBe("1");
+    expect(onChange).toHaveBeenCalledWith("update", "mnt:data:good");
+    expect(onChange).not.toHaveBeenCalledWith("update", "mnt:data:bad");
   });
 
   it("unwatch return", async () => {


### PR DESCRIPTION
### What goes wrong

`setItem`, `setItemRaw` and `removeItem` each end with

```ts
if (!driver.watch) {
  onChange("update", key);
}
```

so a `storage.watch()` callback sees the write whenever the mount's driver has no native watch. `setItems` has no such call, so **batch writes are invisible to watchers**.

That means anything built on `watch` — cache invalidation, HMR, mirrored state — silently goes stale on exactly the writes that touch the most keys, and it only shows up on drivers without a native watch (memory, and most others), which is the common case.

### The change

Emit one `update` per item after the batch lands, under the same `!driver.watch` condition the single-key paths use. Both branches are covered: the native `driver.setItems` path and the `setItem` fallback. Restructured the early `return`s into `if / else if / else` so a single event loop can follow either write path — no behavior change other than the events.

`removeItems` does not exist on `Storage`, so there is no matching gap on the remove side.

### Verification

Two tests in `test/storage.test.ts`, one per branch (memory has no `setItems`, so the second uses a small inline driver that implements it).

Negative control — the tests against unpatched `src/storage.ts`:

```
 × storage > watch: setItems
 × storage > watch: setItems with a driver implementing setItems
AssertionError: expected "vi.fn()" to be called with arguments: [ 'update', 'mnt:etc:conf' ]
Number of calls: 0
```

Zero calls on both paths, which is the bug. With the fix, `vitest run test/storage.test.ts` is 18/18 with no type errors, and `oxlint` / `oxfmt --check` are clean on both files.

Full-suite caveat: `test/drivers/netlify-blobs.test.ts` fails 6 tests here, but it fails identically on a pristine checkout (I stashed and re-ran to confirm), so it is unrelated to this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Multi-item storage updates now continue processing remaining items when one write fails.
  - Successful item updates still trigger notifications even when another item fails.
  - Write failures are still reported after all pending item updates finish.

- **Tests**
  - Added coverage for partial failures and update notifications during multi-item storage operations.
  - Expanded validation for native batch-update behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->