### PR TITLE
perf(fs): prune unrelated getKeys directories

### DIFF
--- a/src/drivers/fs-lite.ts
+++ b/src/drivers/fs-lite.ts
@@ -82,8 +82,8 @@ const driver: DriverFactory<FSStorageOptions> = (opts = {}) => {
       }
       return unlink(r(key)) as Promise<void>;
     },
-    getKeys(_base, topts) {
-      return readdirRecursive(r("."), opts.ignore, topts?.maxDepth);
+    getKeys(keyBase, topts) {
+      return readdirRecursive(r("."), opts.ignore, topts?.maxDepth, keyBase);
     },
     async clear() {
       if (opts.readOnly || opts.noClear) {

--- a/src/drivers/fs.ts
+++ b/src/drivers/fs.ts
@@ -131,8 +131,8 @@ const driver: DriverFactory<FSStorageOptions> = (userOptions = {}) => {
       }
       return unlink(r(key)) as Promise<void>;
     },
-    getKeys(_base, topts) {
-      return readdirRecursive(r("."), ignore, topts?.maxDepth);
+    getKeys(keyBase, topts) {
+      return readdirRecursive(r("."), ignore, topts?.maxDepth, keyBase);
     },
     async clear() {
       if (userOptions.readOnly || userOptions.noClear) {

--- a/src/drivers/utils/node-fs.ts
+++ b/src/drivers/utils/node-fs.ts
@@ -131,6 +131,12 @@ export async function readdirRecursive(
         }
       } else {
         if (!(ignore && ignore(entryPath)) && !TMP_FILE_RE.test(entry.name)) {
+          if (keyBase) {
+            const normalized = normalizeKey(parentKey + "/" + entry.name);
+            if (normalized !== keyBase && !normalized.startsWith(keyBase + ":")) {
+              return;
+            }
+          }
           files.push(entry.name);
         }
       }

--- a/src/drivers/utils/node-fs.ts
+++ b/src/drivers/utils/node-fs.ts
@@ -95,6 +95,7 @@ export async function readdirRecursive(
   keyBase?: string,
   parentKey = "",
 ): Promise<string[]> {
+  keyBase = normalizeKey(keyBase);
   if (ignore && ignore(dir)) {
     return [];
   }
@@ -111,8 +112,9 @@ export async function readdirRecursive(
           // Keep ancestors and descendants that can produce keys under the requested prefix.
           if (
             normalized &&
+            normalized !== keyBase &&
             !keyBase.startsWith(normalized + ":") &&
-            !normalized.startsWith(keyBase)
+            !normalized.startsWith(keyBase + ":")
           ) {
             return;
           }

--- a/src/drivers/utils/node-fs.ts
+++ b/src/drivers/utils/node-fs.ts
@@ -1,6 +1,7 @@
 import { Dirent, existsSync, promises as fsPromises } from "node:fs";
 import { resolve, dirname, join, basename } from "node:path";
 import { randomUUID } from "node:crypto";
+import { normalizeKey } from "../../utils.ts";
 
 function ignoreNotfound(err: any) {
   return err.code === "ENOENT" || err.code === "EISDIR" ? null : err;
@@ -91,6 +92,8 @@ export async function readdirRecursive(
   dir: string,
   ignore?: (p: string) => boolean,
   maxDepth?: number,
+  keyBase?: string,
+  parentKey = "",
 ): Promise<string[]> {
   if (ignore && ignore(dir)) {
     return [];
@@ -101,11 +104,26 @@ export async function readdirRecursive(
     entries.map(async (entry) => {
       const entryPath = resolve(dir, entry.name);
       if (entry.isDirectory()) {
+        let directoryKey = "";
+        if (keyBase) {
+          directoryKey = parentKey + "/" + entry.name;
+          const normalized = normalizeKey(directoryKey);
+          // Keep ancestors and descendants that can produce keys under the requested prefix.
+          if (
+            normalized &&
+            !keyBase.startsWith(normalized + ":") &&
+            !normalized.startsWith(keyBase)
+          ) {
+            return;
+          }
+        }
         if (maxDepth === undefined || maxDepth > 0) {
           const dirFiles = await readdirRecursive(
             entryPath,
             ignore,
             maxDepth === undefined ? undefined : maxDepth - 1,
+            keyBase,
+            directoryKey,
           );
           files.push(...dirFiles.map((f) => entry.name + "/" + f));
         }

--- a/test/drivers/fs-prefix.test.ts
+++ b/test/drivers/fs-prefix.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { promises as fs } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { createStorage } from "../../src/storage.ts";
+import { normalizeBaseKey } from "../../src/utils.ts";
+import fsDriver from "../../src/drivers/fs.ts";
+import fsLiteDriver from "../../src/drivers/fs-lite.ts";
+
+describe.each(["fs", "fs-lite"])("%s prefix traversal", (name) => {
+  let base: string;
+  let storage: ReturnType<typeof createStorage>;
+
+  beforeEach(async () => {
+    base = await fs.mkdtemp(join(tmpdir(), "unstorage-prefix-"));
+    storage = createStorage({ driver: (name === "fs" ? fsDriver : fsLiteDriver)({ base }) });
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await storage.dispose();
+    await fs.rm(base, { recursive: true, force: true });
+  });
+
+  async function write(path: string) {
+    const target = join(base, path);
+    await fs.mkdir(dirname(target), { recursive: true });
+    await fs.writeFile(target, "value");
+  }
+
+  it("reads only the selected namespace and its ancestors", async () => {
+    for (const tenant of ["tenant", "tenant-other", "other", "another"]) {
+      for (const bucket of ["first", "second"]) {
+        await write(`${tenant}/${bucket}/item`);
+      }
+    }
+    const reads = vi.spyOn(fs, "readdir");
+    const all = await storage.getKeys();
+    expect(reads).toHaveBeenCalledTimes(13);
+
+    reads.mockClear();
+    expect((await storage.getKeys("tenant")).sort()).toEqual(
+      all.filter((key) => key.startsWith("tenant:")).sort(),
+    );
+    expect(reads).toHaveBeenCalledTimes(4);
+
+    reads.mockClear();
+    expect(await storage.getKeys("missing")).toEqual([]);
+    expect(reads).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves normalized keys and root-relative depth", async () => {
+    const paths = ["root", "foo/item", "foo/nested/item", "foo/nested/deep/item", "foobar/item"];
+    if (process.platform !== "win32") {
+      paths.push(
+        "foo:compound/item",
+        "foo::repeated/item",
+        "::/foo/item",
+        "foo?query/deep/item",
+        "foo/name\\slash",
+      );
+    }
+    await Promise.all(paths.map(write));
+    for (const maxDepth of [undefined, 0, 1, 2, 3]) {
+      const all = await storage.getKeys("", { maxDepth });
+      for (const prefix of [
+        "foo",
+        "/foo/",
+        "foo:",
+        "foo/nested",
+        "foo/compound",
+        "foo/repeated",
+        "foobar",
+      ]) {
+        expect((await storage.getKeys(prefix, { maxDepth })).sort()).toEqual(
+          all.filter((key) => key.startsWith(normalizeBaseKey(prefix))).sort(),
+        );
+      }
+    }
+  });
+
+  it("preserves ancestor ignores and atomic-file exclusions", async () => {
+    const ignored = join(base, "foo", "ignored");
+    await storage.dispose();
+    storage = createStorage({
+      driver:
+        name === "fs"
+          ? fsDriver({ base, ignore: [ignored] })
+          : fsLiteDriver({ base, ignore: (path) => path === ignored }),
+    });
+    await Promise.all([
+      write("foo/kept/item"),
+      write("foo/ignored/deep/item"),
+      write("foo/.unstorage-tmp-abc"),
+    ]);
+    const reads = vi.spyOn(fs, "readdir");
+    expect(await storage.getKeys("foo/ignored/deep")).toEqual([]);
+    expect(reads.mock.calls.map(([path]) => String(path))).toEqual([base, join(base, "foo")]);
+    expect(await storage.getKeys("foo")).toEqual(["foo:kept:item"]);
+  });
+
+  it("retains failures on the root and selected path but skips unrelated failures", async () => {
+    await Promise.all([write("selected/item"), write("unrelated/item")]);
+    const original = fs.readdir;
+    let failingPath = base;
+    const reads = vi.spyOn(fs, "readdir").mockImplementation(async (...args) => {
+      if (String(args[0]) === failingPath) {
+        throw Object.assign(new Error("denied"), { code: "EACCES" });
+      }
+      return original(...args);
+    });
+    await expect(storage.getKeys("selected")).rejects.toThrow();
+    failingPath = join(base, "selected");
+    await expect(storage.getKeys("selected")).rejects.toThrow();
+    failingPath = join(base, "unrelated");
+    reads.mockClear();
+    expect(await storage.getKeys("selected")).toEqual(["selected:item"]);
+    expect(reads.mock.calls.map(([path]) => String(path))).not.toContain(failingPath);
+    await expect(storage.getKeys()).rejects.toThrow();
+  });
+});

--- a/test/drivers/fs-prefix.test.ts
+++ b/test/drivers/fs-prefix.test.ts
@@ -100,7 +100,12 @@ describe.each(["fs", "fs-lite"])("%s prefix traversal", (name) => {
   });
 
   it("retains failures on the root and selected path but skips unrelated failures", async () => {
-    await Promise.all([write("selected/item"), write("unrelated/item")]);
+    await Promise.all([
+      write("selected/item"),
+      write("unrelated/item"),
+      write("foo/item"),
+      write("foobar/item"),
+    ]);
     const original = fs.readdir;
     let failingPath = base;
     const reads = vi.spyOn(fs, "readdir").mockImplementation(async (...args) => {
@@ -115,6 +120,12 @@ describe.each(["fs", "fs-lite"])("%s prefix traversal", (name) => {
     failingPath = join(base, "unrelated");
     reads.mockClear();
     expect(await storage.getKeys("selected")).toEqual(["selected:item"]);
+    expect(reads.mock.calls.map(([path]) => String(path))).not.toContain(failingPath);
+
+    failingPath = join(base, "foobar");
+    reads.mockClear();
+    const driver = storage.getMount().driver;
+    expect(await driver.getKeys!("foo", {})).toEqual(["foo/item"]);
     expect(reads.mock.calls.map(([path]) => String(path))).not.toContain(failingPath);
     await expect(storage.getKeys()).rejects.toThrow();
   });

--- a/test/drivers/fs-prefix.test.ts
+++ b/test/drivers/fs-prefix.test.ts
@@ -79,6 +79,12 @@ describe.each(["fs", "fs-lite"])("%s prefix traversal", (name) => {
     }
   });
 
+  it("excludes sibling files while traversing a prefix ancestor", async () => {
+    await Promise.all([write("foo/sibling"), write("foo/bar/item")]);
+    const driver = storage.getMount().driver;
+    expect(await driver.getKeys!("foo:bar", {})).toEqual(["foo/bar/item"]);
+  });
+
   it("preserves ancestor ignores and atomic-file exclusions", async () => {
     const ignored = join(base, "foo", "ignored");
     await storage.dispose();


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

`getKeys(base)` now stops before filesystem directories whose normalized path cannot contain that base. The walk still starts at the storage root, so full keys, root-relative `maxDepth`, ignore rules, and mount masking keep their existing behavior.

```diff
 getKeys("tenant-000")
-  walk every tenant directory
+  walk the root and selected tenant
   return matching keys
```

In the pinned fixture, `getKeys("tenant-000")` returns the same 40 keys with 12 directory reads instead of 881. A missing prefix needs one read instead of 881. Unrelated subtrees are no longer visited, so their I/O errors and `fs-lite` ignore-callback calls no longer occur. Errors from the root or selected subtree still reject.

Resolves #819. This also follows the focused fs/fs-lite direction discussed in #546.

Repro: [**Before**](https://github.com/onmax/repros/tree/repro/unstorage-fs-prefix/unstorage-fs-prefix) · [**After**](https://github.com/onmax/repros/tree/repro/unstorage-fs-prefix/unstorage-fs-prefix-fix). Run locally with the commands below.

Copy and run:

```sh
git clone --depth 1 --filter=blob:none --sparse --branch repro/unstorage-fs-prefix https://github.com/onmax/repros.git unstorage-fs-prefix-repro
cd unstorage-fs-prefix-repro
git sparse-checkout set unstorage-fs-prefix unstorage-fs-prefix-fix
cd unstorage-fs-prefix
corepack pnpm install --frozen-lockfile --ignore-scripts && corepack pnpm verify
cd ../unstorage-fs-prefix-fix
corepack pnpm install --frozen-lockfile --ignore-scripts && corepack pnpm verify
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed directory-scoped key enumeration so results are limited to the requested namespace and its ancestors.
  - Preserved normalized keys and accurate depth handling across supported prefix formats.
  - Improved filtering of ignored directories, atomic files, and unrelated paths during traversal.
  - Continued reporting errors encountered at the root or within the selected namespace.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
