### PR TITLE
feat(drivers): add React Native MMKV driver and docs

### DIFF
--- a/docs/2.drivers/0.index.md
+++ b/docs/2.drivers/0.index.md
@@ -32,6 +32,7 @@ Without a `driver` option, `createStorage()` uses the [memory driver](/drivers/m
 | [Session storage](/drivers/browser) | `unstorage/drivers/session-storage` | Browser `sessionStorage`. |
 | [IndexedDB](/drivers/browser#indexeddb) | `unstorage/drivers/indexeddb` | Browser database through `idb-keyval`. |
 | [Capacitor Preferences](/drivers/capacitor-preferences) | `unstorage/drivers/capacitor-preferences` | Mobile preferences and web fallback. |
+| [React Native (MMKV)](/drivers/react-native-mmkv) | `unstorage/drivers/react-native-mmkv` | Fast key-value storage for React Native apps. |
 | [Deno KV](/drivers/deno) | `unstorage/drivers/deno-kv` | Deno runtime and Deno Deploy. |
 | [Deno KV for Node.js](/drivers/deno#usage-nodejs) | `unstorage/drivers/deno-kv-node` | Remote or local Deno KV through `@deno/kv`. |
 | [LRU Cache](/drivers/lru-cache) | `unstorage/drivers/lru-cache` | Bounded in-process cache. |

--- a/docs/2.drivers/react-native-mmkv.md
+++ b/docs/2.drivers/react-native-mmkv.md
@@ -1,0 +1,50 @@
+---
+icon: simple-icons:react
+---
+
+# React Native (MMKV)
+
+> Store data via [react-native-mmkv](https://github.com/mrousavy/react-native-mmkv) in React Native apps. Fast key-value storage (~30x faster than AsyncStorage).
+
+::read-more{to="https://github.com/mrousavy/react-native-mmkv"}
+Learn more about react-native-mmkv.
+::
+
+## Usage
+
+**Driver name:** `react-native-mmkv`
+
+Install the package in your React Native project, then use unstorage:
+
+:pm-install{name="react-native-mmkv"}
+:pm-install{name="unstorage"}
+
+Usage:
+
+```js
+import { createStorage } from "unstorage";
+import reactNativeMmkv from "unstorage/drivers/react-native-mmkv";
+
+const storage = createStorage({
+  driver: reactNativeMmkv({
+    id: "app-storage",
+    base: "app",
+    encryptionKey: "optional-encryption-key",
+  }),
+});
+```
+
+**Options:**
+
+- `base`: Optional prefix for all keys (namespace).
+- `id`: MMKV instance ID (default: `mmkv.default`). Use different IDs for multiple instances.
+- `path`: Custom root path for the storage file.
+- `encryptionKey`: Optional encryption key. Max 16 bytes with `AES-128` (default), 32 bytes with `AES-256`.
+- `encryptionType`: `AES-128` (default) or `AES-256`.
+- `mode`: `single-process` (default) or `multi-process`.
+- `readOnly`: If true, storage is read-only. Default: `false`.
+- `lib`: An imported `react-native-mmkv` module or a function that returns it.
+
+The driver supports `watch` via MMKV's `addOnValueChangedListener` for key updates. The library is loaded lazily on first use, so install it only in React Native targets that actually use this driver.
+
+**Requirements:** react-native-mmkv v4 is built on Nitro Modules. It requires React Native 0.75+ and the [`react-native-nitro-modules`](https://github.com/margelo/nitro) peer dependency (installed automatically with react-native-mmkv).

--- a/src/_drivers.ts
+++ b/src/_drivers.ts
@@ -27,6 +27,7 @@ import type { MongoDbOptions as MongodbOptions } from "unstorage/drivers/mongodb
 import type { NetlifyStoreOptions as NetlifyBlobsOptions } from "unstorage/drivers/netlify-blobs";
 import type { OverlayStorageOptions as OverlayOptions } from "unstorage/drivers/overlay";
 import type { PlanetscaleDriverOptions as PlanetscaleOptions } from "unstorage/drivers/planetscale";
+import type { ReactNativeMmkvDriverOptions as ReactNativeMmKVOptions } from "unstorage/drivers/react-native-mmkv";
 import type { RedisOptions } from "unstorage/drivers/redis";
 import type { S3DriverOptions as S3Options } from "unstorage/drivers/s3";
 import type { SessionStorageOptions } from "unstorage/drivers/session-storage";
@@ -35,7 +36,7 @@ import type { UpstashOptions } from "unstorage/drivers/upstash";
 import type { VercelBlobOptions } from "unstorage/drivers/vercel-blob";
 import type { VercelCacheOptions as VercelRuntimeCacheOptions } from "unstorage/drivers/vercel-runtime-cache";
 
-export type BuiltinDriverName = "azure-app-configuration" | "azureAppConfiguration" | "azure-cosmos" | "azureCosmos" | "azure-key-vault" | "azureKeyVault" | "azure-storage-blob" | "azureStorageBlob" | "azure-storage-table" | "azureStorageTable" | "capacitor-preferences" | "capacitorPreferences" | "cloudflare-cache-binding" | "cloudflareCacheBinding" | "cloudflare-kv-binding" | "cloudflareKVBinding" | "cloudflare-kv-http" | "cloudflareKVHttp" | "cloudflare-r2-binding" | "cloudflareR2Binding" | "db0" | "deno-kv-node" | "denoKVNode" | "deno-kv" | "denoKV" | "fs-lite" | "fsLite" | "fs" | "github" | "http" | "indexedb" | "localstorage" | "lru-cache" | "lruCache" | "memory" | "mongodb" | "netlify-blobs" | "netlifyBlobs" | "null" | "overlay" | "planetscale" | "redis" | "s3" | "session-storage" | "sessionStorage" | "uploadthing" | "upstash" | "vercel-blob" | "vercelBlob" | "vercel-runtime-cache" | "vercelRuntimeCache";
+export type BuiltinDriverName = "azure-app-configuration" | "azureAppConfiguration" | "azure-cosmos" | "azureCosmos" | "azure-key-vault" | "azureKeyVault" | "azure-storage-blob" | "azureStorageBlob" | "azure-storage-table" | "azureStorageTable" | "capacitor-preferences" | "capacitorPreferences" | "cloudflare-cache-binding" | "cloudflareCacheBinding" | "cloudflare-kv-binding" | "cloudflareKVBinding" | "cloudflare-kv-http" | "cloudflareKVHttp" | "cloudflare-r2-binding" | "cloudflareR2Binding" | "db0" | "deno-kv-node" | "denoKVNode" | "deno-kv" | "denoKV" | "fs-lite" | "fsLite" | "fs" | "github" | "http" | "indexedb" | "localstorage" | "lru-cache" | "lruCache" | "memory" | "mongodb" | "netlify-blobs" | "netlifyBlobs" | "null" | "overlay" | "planetscale" | "react-native-mmkv" | "reactNativeMmKV" | "redis" | "s3" | "session-storage" | "sessionStorage" | "uploadthing" | "upstash" | "vercel-blob" | "vercelBlob" | "vercel-runtime-cache" | "vercelRuntimeCache";
 
 export type BuiltinDriverOptions = {
   "azure-app-configuration": AzureAppConfigurationOptions;
@@ -77,6 +78,8 @@ export type BuiltinDriverOptions = {
   "netlifyBlobs": NetlifyBlobsOptions;
   "overlay": OverlayOptions;
   "planetscale": PlanetscaleOptions;
+  "react-native-mmkv": ReactNativeMmKVOptions;
+  "reactNativeMmKV": ReactNativeMmKVOptions;
   "redis": RedisOptions;
   "s3": S3Options;
   "session-storage": SessionStorageOptions;
@@ -131,6 +134,8 @@ export const builtinDrivers = {
   "null": "unstorage/drivers/null",
   "overlay": "unstorage/drivers/overlay",
   "planetscale": "unstorage/drivers/planetscale",
+  "react-native-mmkv": "unstorage/drivers/react-native-mmkv",
+  "reactNativeMmKV": "unstorage/drivers/react-native-mmkv",
   "redis": "unstorage/drivers/redis",
   "s3": "unstorage/drivers/s3",
   "session-storage": "unstorage/drivers/session-storage",
@@ -228,6 +233,12 @@ export const builtinDriverDependencies: Partial<Record<BuiltinDriverName, Driver
   },
   "planetscale": {
     lib: { name: "@planetscale/database", version: "^1.19.0" },
+  },
+  "react-native-mmkv": {
+    lib: { name: "react-native-mmkv", version: "^4.0.0" },
+  },
+  "reactNativeMmKV": {
+    lib: { name: "react-native-mmkv", version: "^4.0.0" },
   },
   "redis": {
     lib: { name: "ioredis", version: "^5.9.3 || ^6" },

--- a/src/drivers/react-native-mmkv.ts
+++ b/src/drivers/react-native-mmkv.ts
@@ -1,0 +1,113 @@
+import {
+  type DriverDependencies,
+  type DriverFactory,
+  importLib,
+  joinKeys,
+  type LibImport,
+  normalizeKey,
+} from "./utils/index.ts";
+
+const DRIVER_NAME = "react-native-mmkv";
+
+export interface ReactNativeMmkvDriverOptions extends Omit<
+  import("react-native-mmkv").Configuration,
+  "id"
+> {
+  /**
+   * The MMKV instance's ID. Defaults to `"mmkv.default"`.
+   */
+  id?: string;
+  /**
+   * Optional prefix for all keys (namespace).
+   */
+  base?: string;
+  /**
+   * Optionally provide the [`react-native-mmkv`](https://github.com/mrousavy/react-native-mmkv)
+   * library to avoid dynamically importing it.
+   */
+  lib?: LibImport<typeof import("react-native-mmkv")>;
+}
+
+export const DRIVER_DEPENDENCIES: DriverDependencies = {
+  lib: { name: "react-native-mmkv", version: "^4.0.0" },
+};
+
+type MmkvInstance = import("react-native-mmkv").MMKV;
+
+const driver: DriverFactory<ReactNativeMmkvDriverOptions, Promise<MmkvInstance>> = (opts) => {
+  const { base: baseOpt, lib: _lib, id, ...mmkvConfig } = opts ?? {};
+  const base = normalizeKey(baseOpt || "");
+  const resolveKey = (key: string) => joinKeys(base, key);
+
+  const mmkvPromise = importLib(
+    DRIVER_NAME,
+    "react-native-mmkv",
+    opts?.lib,
+    () => import("react-native-mmkv"),
+  ).then((lib) => lib.createMMKV({ id: id ?? "mmkv.default", ...mmkvConfig }));
+
+  return {
+    name: DRIVER_NAME,
+    options: opts,
+    getInstance: () => mmkvPromise,
+    async hasItem(key) {
+      const mmkv = await mmkvPromise;
+      return mmkv.contains(resolveKey(key));
+    },
+    async getItem(key) {
+      const mmkv = await mmkvPromise;
+      return mmkv.getString(resolveKey(key)) ?? null;
+    },
+    async setItem(key, value) {
+      const mmkv = await mmkvPromise;
+      mmkv.set(resolveKey(key), value);
+    },
+    async removeItem(key) {
+      const mmkv = await mmkvPromise;
+      mmkv.remove(resolveKey(key));
+    },
+    async getKeys(basePrefix) {
+      const mmkv = await mmkvPromise;
+      const prefix = resolveKey(basePrefix || "");
+      const allKeys = mmkv.getAllKeys();
+      if (!prefix) {
+        return base
+          ? allKeys
+              .filter((k) => k === base || k.startsWith(base + ":"))
+              .map((k) => k.slice(base.length + 1))
+              .filter(Boolean)
+          : allKeys;
+      }
+      return allKeys
+        .filter((k) => k === prefix || k.startsWith(prefix + ":"))
+        .map((k) => (base ? k.slice(base.length + 1) : k))
+        .filter(Boolean);
+    },
+    async clear(basePrefix) {
+      const mmkv = await mmkvPromise;
+      const prefix = resolveKey(basePrefix || "");
+      const allKeys = mmkv.getAllKeys();
+      const toRemove = prefix
+        ? allKeys.filter((k) => k === prefix || k.startsWith(prefix + ":"))
+        : base
+          ? allKeys.filter((k) => k === base || k.startsWith(base + ":"))
+          : allKeys;
+      for (const k of toRemove) {
+        mmkv.remove(k);
+      }
+    },
+    async watch(callback) {
+      const mmkv = await mmkvPromise;
+      const listener = mmkv.addOnValueChangedListener((key) => {
+        if (base && key !== base && !key.startsWith(base + ":")) {
+          return;
+        }
+        const scopedKey = base ? (key === base ? "" : key.slice(base.length + 1)) : key;
+        callback("update", scopedKey);
+      });
+      return () => listener.remove();
+    },
+  };
+};
+
+export default driver;

--- a/src/react-native-mmkv.d.ts
+++ b/src/react-native-mmkv.d.ts
@@ -1,0 +1,60 @@
+// Ambient type declarations for the optional `react-native-mmkv` peer library
+// (https://github.com/mrousavy/react-native-mmkv).
+//
+// The package is intentionally NOT installed as a devDependency: it only ships
+// native modules, and its type declarations (via `react-native-nitro-modules`)
+// inject React Native globals that pollute the compiler environment. These
+// declarations mirror the public v4 API so `import("react-native-mmkv")`
+// resolves during type-checking. The real library is loaded dynamically at
+// runtime through the driver's `lib` option / `DRIVER_DEPENDENCIES`.
+declare module "react-native-mmkv" {
+  export interface Configuration {
+    /**
+     * The MMKV instance's ID. Defaults to `"mmkv.default"`.
+     */
+    id: string;
+    /**
+     * Custom root path for the storage file.
+     */
+    path?: string;
+    /**
+     * Optional encryption key. Max 16 bytes with `AES-128` (default), 32 bytes
+     * with `AES-256`.
+     */
+    encryptionKey?: string;
+    /**
+     * Encryption algorithm. Defaults to `AES-128`.
+     */
+    encryptionType?: "AES-128" | "AES-256";
+    /**
+     * Processing mode. Defaults to `single-process`.
+     */
+    mode?: "single-process" | "multi-process";
+    /**
+     * Read-only mode. Defaults to `false`.
+     */
+    readOnly?: boolean;
+    /**
+     * Skip the file write when the stored value is unchanged.
+     */
+    compareBeforeSet?: boolean;
+    /**
+     * How to handle recoverable storage errors.
+     */
+    recoveryStrategy?: "discard-on-error" | "recover-on-error";
+  }
+
+  export interface MMKV {
+    contains(key: string): boolean;
+    getString(key: string): string | undefined;
+    set(key: string, value: boolean | string | number | ArrayBuffer): void;
+    remove(key: string): boolean;
+    getAllKeys(): string[];
+    clearAll(): void;
+    addOnValueChangedListener(
+      onValueChanged: (key: string) => void,
+    ): { remove(): void };
+  }
+
+  export function createMMKV(config?: Configuration): MMKV;
+}

--- a/test/drivers/react-native-mmkv.test.ts
+++ b/test/drivers/react-native-mmkv.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it, vi } from "vitest";
+
+import driver, { type ReactNativeMmkvDriverOptions } from "../../src/drivers/react-native-mmkv.ts";
+import { testDriver } from "./utils.ts";
+
+function createMockMMKV() {
+  const data = new Map<string, string>();
+  const listeners = new Set<(key: string) => void>();
+  const emit = (key: string) => {
+    for (const cb of listeners) {
+      cb(key);
+    }
+  };
+  const mmkv = {
+    contains: (key: string) => data.has(key),
+    getString: (key: string) => data.get(key),
+    set: (key: string, value: string) => {
+      data.set(key, value);
+      emit(key);
+    },
+    remove: (key: string) => {
+      const removed = data.delete(key);
+      if (removed) {
+        emit(key);
+      }
+      return removed;
+    },
+    getAllKeys: () => [...data.keys()],
+    clearAll: () => {
+      data.clear();
+    },
+    addOnValueChangedListener: vi.fn((cb: (key: string) => void) => {
+      listeners.add(cb);
+      return { remove: () => listeners.delete(cb) };
+    }),
+  };
+  return { mmkv, emit, data };
+}
+
+function createDriver(opts: ReactNativeMmkvDriverOptions) {
+  const { mmkv, emit } = createMockMMKV();
+  const createMMKV = vi.fn(() => mmkv);
+  const lib = { createMMKV } as unknown as NonNullable<ReactNativeMmkvDriverOptions["lib"]>;
+  return { driver: driver({ ...opts, lib }), createMMKV, emit, mmkv };
+}
+
+describe("drivers: react-native-mmkv", () => {
+  testDriver({
+    driver: () => createDriver({ id: "test" }).driver,
+  });
+
+  testDriver({
+    driver: () => createDriver({ id: "test-with-base", base: "app" }).driver,
+  });
+
+  it("creates a MMKV instance with the provided configuration", async () => {
+    const { driver, createMMKV } = createDriver({
+      id: "custom-id",
+      path: "/tmp/storage",
+      encryptionKey: "encryptionkey123",
+      mode: "single-process",
+    });
+    await driver.getInstance?.();
+    expect(createMMKV).toHaveBeenCalledWith({
+      id: "custom-id",
+      path: "/tmp/storage",
+      encryptionKey: "encryptionkey123",
+      mode: "single-process",
+    });
+  });
+
+  it("uses the default instance id when not provided", async () => {
+    const { driver, createMMKV } = createDriver({});
+    await driver.getInstance?.();
+    expect(createMMKV).toHaveBeenCalledWith({
+      id: "mmkv.default",
+    });
+  });
+
+  it("watch() emits update events for keys in the base namespace", async () => {
+    const { driver, emit } = createDriver({ id: "watched", base: "app" });
+    const callback = vi.fn();
+    const unwatch = await driver.watch!(callback);
+
+    emit("app:foo");
+    expect(callback).toHaveBeenCalledWith("update", "foo");
+
+    emit("app:bar");
+    expect(callback).toHaveBeenCalledWith("update", "bar");
+
+    // Keys outside the base namespace are ignored
+    emit("other:key");
+    expect(callback).toHaveBeenCalledTimes(2);
+
+    // Keys in the base namespace without a prefix are scoped to ""
+    emit("app");
+    expect(callback).toHaveBeenCalledWith("update", "");
+
+    unwatch();
+    emit("app:baz");
+    expect(callback).toHaveBeenCalledTimes(3);
+  });
+
+  it("watch() emits update events for all keys without a base", async () => {
+    const { driver, emit } = createDriver({ id: "watched" });
+    const callback = vi.fn();
+    const unwatch = await driver.watch!(callback);
+
+    emit("foo");
+    expect(callback).toHaveBeenCalledWith("update", "foo");
+
+    unwatch();
+  });
+});


### PR DESCRIPTION
Resolves #749.

Adds a React Native eact-native-mmkv driver, rewritten on top of the latest main branch:

- Adopts the dynamic import pattern: \DRIVER_DEPENDENCIES\ + \importLib()\, with a \lib\ option to inject the library (e.g. for tests or bundler issues).
- Uses the v4 API (\createMMKV()\, \emove()\) and scopes \watch()\ to the configured \ase\ namespace.
- \eact-native-mmkv\ is intentionally not installed as a devDependency: it only ships native modules and its type declarations (via \eact-native-nitro-modules\) pollute the TypeScript environment. An ambient declaration (\src/react-native-mmkv.d.ts\) mirrors the public v4 surface for type-checking.
- Tests use the \lib\ injection instead of \i.mock\ (vite does not intercept dynamic imports of externalized CJS modules inside the driver), and add \watch()\ coverage. \fterEach\ is imported from vitest, not \
ode:test\.

Supersedes the previously closed #754.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for React Native MMKV as a local storage driver.
  * Supports configurable instances, namespacing, asynchronous storage operations, key management, and change watching.
  * Added configuration options for encryption, process mode, read-only access, recovery, and custom library injection.

* **Documentation**
  * Added setup, usage, configuration, and compatibility documentation for the React Native MMKV driver.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->