### PR TITLE
feat(drivers): add React Native AsyncStorage driver

### DIFF
--- a/docs/2.drivers/0.index.md
+++ b/docs/2.drivers/0.index.md
@@ -32,6 +32,7 @@ Without a `driver` option, `createStorage()` uses the [memory driver](/drivers/m
 | [Session storage](/drivers/browser) | `unstorage/drivers/session-storage` | Browser `sessionStorage`. |
 | [IndexedDB](/drivers/browser#indexeddb) | `unstorage/drivers/indexeddb` | Browser database through `idb-keyval`. |
 | [Capacitor Preferences](/drivers/capacitor-preferences) | `unstorage/drivers/capacitor-preferences` | Mobile preferences and web fallback. |
+| [React Native AsyncStorage](/drivers/react-native-async-storage) | `unstorage/drivers/react-native-async-storage` | React Native persistent key-value storage. |
 | [Deno KV](/drivers/deno) | `unstorage/drivers/deno-kv` | Deno runtime and Deno Deploy. |
 | [Deno KV for Node.js](/drivers/deno#usage-nodejs) | `unstorage/drivers/deno-kv-node` | Remote or local Deno KV through `@deno/kv`. |
 | [LRU Cache](/drivers/lru-cache) | `unstorage/drivers/lru-cache` | Bounded in-process cache. |

--- a/docs/2.drivers/react-native-async-storage.md
+++ b/docs/2.drivers/react-native-async-storage.md
@@ -1,0 +1,28 @@
+---
+icon: simple-icons:react
+---
+
+# React Native AsyncStorage
+
+Use [React Native AsyncStorage](https://github.com/react-native-async-storage/async-storage) as an Unstorage driver.
+
+## Usage
+
+```ts
+import asyncStorageDriver from "unstorage/drivers/react-native-async-storage";
+
+const storage = createStorage({
+  driver: asyncStorageDriver({
+    base: "app",
+  }),
+});
+```
+
+Install the peer dependency with `:pm-install{name="@react-native-async-storage/async-storage"}`.
+
+## Options
+
+- `base`: Optional namespace prefix for stored keys.
+- `lib`: Optional AsyncStorage module (or loader) for bundlers and dependency injection.
+
+AsyncStorage does not provide change notifications, so this driver does not support `watch`.

--- a/src/_drivers.ts
+++ b/src/_drivers.ts
@@ -27,6 +27,7 @@ import type { MongoDbOptions as MongodbOptions } from "unstorage/drivers/mongodb
 import type { NetlifyStoreOptions as NetlifyBlobsOptions } from "unstorage/drivers/netlify-blobs";
 import type { OverlayStorageOptions as OverlayOptions } from "unstorage/drivers/overlay";
 import type { PlanetscaleDriverOptions as PlanetscaleOptions } from "unstorage/drivers/planetscale";
+import type { ReactNativeAsyncStorageOptions } from "unstorage/drivers/react-native-async-storage";
 import type { RedisOptions } from "unstorage/drivers/redis";
 import type { S3DriverOptions as S3Options } from "unstorage/drivers/s3";
 import type { SessionStorageOptions } from "unstorage/drivers/session-storage";
@@ -35,7 +36,7 @@ import type { UpstashOptions } from "unstorage/drivers/upstash";
 import type { VercelBlobOptions } from "unstorage/drivers/vercel-blob";
 import type { VercelCacheOptions as VercelRuntimeCacheOptions } from "unstorage/drivers/vercel-runtime-cache";
 
-export type BuiltinDriverName = "azure-app-configuration" | "azureAppConfiguration" | "azure-cosmos" | "azureCosmos" | "azure-key-vault" | "azureKeyVault" | "azure-storage-blob" | "azureStorageBlob" | "azure-storage-table" | "azureStorageTable" | "capacitor-preferences" | "capacitorPreferences" | "cloudflare-cache-binding" | "cloudflareCacheBinding" | "cloudflare-kv-binding" | "cloudflareKVBinding" | "cloudflare-kv-http" | "cloudflareKVHttp" | "cloudflare-r2-binding" | "cloudflareR2Binding" | "db0" | "deno-kv-node" | "denoKVNode" | "deno-kv" | "denoKV" | "fs-lite" | "fsLite" | "fs" | "github" | "http" | "indexedb" | "localstorage" | "lru-cache" | "lruCache" | "memory" | "mongodb" | "netlify-blobs" | "netlifyBlobs" | "null" | "overlay" | "planetscale" | "redis" | "s3" | "session-storage" | "sessionStorage" | "uploadthing" | "upstash" | "vercel-blob" | "vercelBlob" | "vercel-runtime-cache" | "vercelRuntimeCache";
+export type BuiltinDriverName = "azure-app-configuration" | "azureAppConfiguration" | "azure-cosmos" | "azureCosmos" | "azure-key-vault" | "azureKeyVault" | "azure-storage-blob" | "azureStorageBlob" | "azure-storage-table" | "azureStorageTable" | "capacitor-preferences" | "capacitorPreferences" | "cloudflare-cache-binding" | "cloudflareCacheBinding" | "cloudflare-kv-binding" | "cloudflareKVBinding" | "cloudflare-kv-http" | "cloudflareKVHttp" | "cloudflare-r2-binding" | "cloudflareR2Binding" | "db0" | "deno-kv-node" | "denoKVNode" | "deno-kv" | "denoKV" | "fs-lite" | "fsLite" | "fs" | "github" | "http" | "indexedb" | "localstorage" | "lru-cache" | "lruCache" | "memory" | "mongodb" | "netlify-blobs" | "netlifyBlobs" | "null" | "overlay" | "planetscale" | "react-native-async-storage" | "reactNativeAsyncStorage" | "redis" | "s3" | "session-storage" | "sessionStorage" | "uploadthing" | "upstash" | "vercel-blob" | "vercelBlob" | "vercel-runtime-cache" | "vercelRuntimeCache";
 
 export type BuiltinDriverOptions = {
   "azure-app-configuration": AzureAppConfigurationOptions;
@@ -77,6 +78,8 @@ export type BuiltinDriverOptions = {
   "netlifyBlobs": NetlifyBlobsOptions;
   "overlay": OverlayOptions;
   "planetscale": PlanetscaleOptions;
+  "react-native-async-storage": ReactNativeAsyncStorageOptions;
+  "reactNativeAsyncStorage": ReactNativeAsyncStorageOptions;
   "redis": RedisOptions;
   "s3": S3Options;
   "session-storage": SessionStorageOptions;
@@ -131,6 +134,8 @@ export const builtinDrivers = {
   "null": "unstorage/drivers/null",
   "overlay": "unstorage/drivers/overlay",
   "planetscale": "unstorage/drivers/planetscale",
+  "react-native-async-storage": "unstorage/drivers/react-native-async-storage",
+  "reactNativeAsyncStorage": "unstorage/drivers/react-native-async-storage",
   "redis": "unstorage/drivers/redis",
   "s3": "unstorage/drivers/s3",
   "session-storage": "unstorage/drivers/session-storage",
@@ -228,6 +233,12 @@ export const builtinDriverDependencies: Partial<Record<BuiltinDriverName, Driver
   },
   "planetscale": {
     lib: { name: "@planetscale/database", version: "^1.19.0" },
+  },
+  "react-native-async-storage": {
+    lib: { name: "@react-native-async-storage/async-storage", version: "^2 || ^3" },
+  },
+  "reactNativeAsyncStorage": {
+    lib: { name: "@react-native-async-storage/async-storage", version: "^2 || ^3" },
   },
   "redis": {
     lib: { name: "ioredis", version: "^5.9.3 || ^6" },

--- a/src/drivers/react-native-async-storage.ts
+++ b/src/drivers/react-native-async-storage.ts
@@ -1,0 +1,77 @@
+import type AsyncStorage from "@react-native-async-storage/async-storage";
+
+import {
+  type DriverFactory,
+  type DriverDependencies,
+  importLib,
+  joinKeys,
+  type LibImport,
+  normalizeKey,
+} from "./utils/index.ts";
+
+export const DRIVER_DEPENDENCIES: DriverDependencies = {
+  lib: { name: "@react-native-async-storage/async-storage", version: "^2 || ^3" },
+};
+
+const DRIVER_NAME = "react-native-async-storage";
+
+export interface ReactNativeAsyncStorageOptions {
+  base?: string;
+  /** Optionally provide AsyncStorage to avoid dynamically importing it. */
+  lib?: LibImport<typeof AsyncStorage>;
+}
+
+const driver: DriverFactory<ReactNativeAsyncStorageOptions, Promise<typeof AsyncStorage>> = (opts) => {
+  const base = normalizeKey(opts?.base);
+  const resolveKey = (key: string) => joinKeys(base, key);
+  let storage: Promise<typeof AsyncStorage> | undefined;
+  const getStorage = () =>
+    (storage ??= importLib(
+      DRIVER_NAME,
+      "@react-native-async-storage/async-storage",
+      opts?.lib,
+      () => import("@react-native-async-storage/async-storage"),
+    ));
+
+  return {
+    name: DRIVER_NAME,
+    options: opts,
+    getInstance: () => getStorage(),
+    async hasItem(key) {
+      return (await (await getStorage()).getItem(resolveKey(key))) !== null;
+    },
+    async getItem(key) {
+      return (await getStorage()).getItem(resolveKey(key));
+    },
+    async getItemRaw(key) {
+      return (await getStorage()).getItem(resolveKey(key));
+    },
+    async setItem(key, value) {
+      await (await getStorage()).setItem(resolveKey(key), value);
+    },
+    async setItemRaw(key, value) {
+      await (await getStorage()).setItem(resolveKey(key), value);
+    },
+    async removeItem(key) {
+      await (await getStorage()).removeItem(resolveKey(key));
+    },
+    async getKeys() {
+      const prefix = base ? `${base}:` : "";
+      return (await (await getStorage()).getAllKeys())
+        .filter((key) => !prefix || key.startsWith(prefix))
+        .map((key) => (prefix ? key.slice(prefix.length) : key));
+    },
+    async clear(prefix) {
+      const storage = await getStorage();
+      const keyPrefix = resolveKey(prefix || "");
+      if (!keyPrefix) {
+        await storage.clear();
+        return;
+      }
+      const keys = await storage.getAllKeys();
+      await storage.multiRemove(keys.filter((key) => key === keyPrefix || key.startsWith(`${keyPrefix}:`)));
+    },
+  };
+};
+
+export default driver;

--- a/src/react-native-async-storage.d.ts
+++ b/src/react-native-async-storage.d.ts
@@ -1,0 +1,12 @@
+declare module "@react-native-async-storage/async-storage" {
+  interface AsyncStorageStatic {
+    getItem(key: string): Promise<string | null>;
+    setItem(key: string, value: string): Promise<void>;
+    removeItem(key: string): Promise<void>;
+    getAllKeys(): Promise<readonly string[]>;
+    multiRemove(keys: readonly string[]): Promise<void>;
+    clear(): Promise<void>;
+  }
+  const AsyncStorage: AsyncStorageStatic;
+  export default AsyncStorage;
+}

--- a/test/drivers/react-native-async-storage.test.ts
+++ b/test/drivers/react-native-async-storage.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from "vitest";
+import { createStorage } from "../../src/index.ts";
+import { testDriver } from "./utils.ts";
+import driver, { type ReactNativeAsyncStorageOptions } from "../../src/drivers/react-native-async-storage.ts";
+
+function createMock() {
+  const data = new Map<string, string>();
+  const lib = {
+    getItem: vi.fn(async (key: string) => data.get(key) ?? null),
+    setItem: vi.fn(async (key: string, value: string) => void data.set(key, value)),
+    removeItem: vi.fn(async (key: string) => void data.delete(key)),
+    getAllKeys: vi.fn(async () => [...data.keys()]),
+    multiRemove: vi.fn(async (keys: readonly string[]) => keys.forEach((key) => data.delete(key))),
+    clear: vi.fn(async () => void data.clear()),
+  };
+  return lib;
+}
+
+const mock = createMock();
+
+function createDriver(base?: string) {
+  return { driver: driver({ base, lib: mock } as ReactNativeAsyncStorageOptions), lib: mock };
+}
+
+describe("react-native-async-storage", () => {
+  testDriver({ driver: () => {
+    mock.clear();
+    return createDriver().driver;
+  } });
+
+  it("supports base namespaces", async () => {
+    const { driver: instance, lib } = createDriver("app");
+    const storage = createStorage({ driver: instance });
+    await storage.setItem("foo", "bar");
+    expect(lib.setItem).toHaveBeenCalledWith("app:foo", '"bar"');
+    expect(await storage.getKeys()).toEqual(["foo"]);
+    await storage.clear();
+    expect(lib.clear).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #752 
Adds a React Native AsyncStorage driver with namespace support, dynamic dependency loading, injectable lib support, tests, and documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a React Native AsyncStorage driver for persistent key-value storage.
  * Supports optional key prefixes, custom storage instances, key listing, and scoped clearing.
  * Added setup guidance, configuration options, dependency requirements, and the limitation that watching changes is unsupported.
* **Tests**
  * Added coverage for storage operations and prefixed namespaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->