### PR TITLE
fix(utils): detect plain objects by their prototype chain

### DIFF
--- a/src/_utils.ts
+++ b/src/_utils.ts
@@ -26,8 +26,13 @@ function isPrimitive(value: any) {
 
 function isPureObject(value: any) {
   const proto = Object.getPrototypeOf(value);
-  // eslint-disable-next-line no-prototype-builtins
-  return !proto || proto.isPrototypeOf(Object);
+  // A pure object is `{}`-like: either it has no prototype at all, or its
+  // prototype is an `Object.prototype` (which itself has no prototype). The
+  // second form is checked structurally rather than only with
+  // `=== Object.prototype` so that plain objects coming from another realm
+  // (`node:vm`, a worker, an iframe) are recognized too.
+  // Same shape as https://github.com/sindresorhus/is-plain-obj.
+  return proto === null || proto === Object.prototype || Object.getPrototypeOf(proto) === null;
 }
 
 export function stringify(value: any): string {

--- a/test/storage.test.ts
+++ b/test/storage.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import { resolve } from "node:path";
+import { runInNewContext } from "node:vm";
 import { createStorage, snapshot, restoreSnapshot, prefixStorage } from "../src/index.ts";
 import memory from "../src/drivers/memory.ts";
 import fs from "../src/drivers/fs.ts";
@@ -169,6 +170,36 @@ describe("utils", () => {
   it("stringify", () => {
     const storage = createStorage();
     expect(async () => await storage.setItem("foo", [])).not.toThrow();
+  });
+
+  it("stringify accepts a plain object from another realm", async () => {
+    const storage = createStorage();
+    // A `{}` built in another realm (`node:vm`, a worker, an iframe) does not
+    // share this realm's `Object.prototype`, but it is still a plain object.
+    const foreignObject = runInNewContext("({ foo: 'bar' })");
+    await storage.setItem("foo", foreignObject);
+    expect(await storage.getItem("foo")).toEqual({ foo: "bar" });
+  });
+
+  it("stringify rejects a non-plain object without a toJSON", async () => {
+    const storage = createStorage();
+    // `Object.create(Function.prototype)` is not a plain object: its prototype
+    // chain does not end right after it.
+    await expect(storage.setItem("foo", Object.create(Function.prototype))).rejects.toThrow(
+      "[unstorage] Cannot stringify value!",
+    );
+    await expect(storage.setItem("foo", Object.create({}))).rejects.toThrow(
+      "[unstorage] Cannot stringify value!",
+    );
+  });
+
+  it("stringify accepts an object whose prototype is null-prototyped", async () => {
+    const storage = createStorage();
+    // Used to throw `TypeError: proto.isPrototypeOf is not a function`.
+    const value = Object.create(Object.create(null));
+    value.foo = "bar";
+    await storage.setItem("foo", value);
+    expect(await storage.getItem("foo")).toEqual({ foo: "bar" });
   });
 
   it("has aliases", async () => {


### PR DESCRIPTION
`isPureObject` in `src/_utils.ts` decides whether `stringify` may `JSON.stringify` a value:

```js
function isPureObject(value) {
  const proto = Object.getPrototypeOf(value);
  return !proto || proto.isPrototypeOf(Object);
}
```

`proto.isPrototypeOf(Object)` asks *"is `proto` somewhere in the prototype chain of the `Object` constructor?"* — the reverse of the intended check, and unrelated to whether `value` is a plain object. `Object` is a function, so its chain is `Function.prototype -> Object.prototype -> null`; the test therefore passes for exactly `Object.prototype` and `Function.prototype`, by coincidence rather than by intent.

Three consequences, all reproducible on `main`:

```js
import { createStorage } from "unstorage";
import { runInNewContext } from "node:vm";

const storage = createStorage();

// 1. A plain object from another realm is rejected.
await storage.setItem("a", runInNewContext("({ foo: 'bar' })"));
// -> Error: [unstorage] Cannot stringify value!

// 2. A non-plain object is accepted.
await storage.setItem("b", Object.assign(Object.create(Function.prototype), { foo: 1 }));
// -> stored as '{"foo":1}'

// 3. A value whose prototype is itself null-prototyped crashes.
await storage.setItem("c", Object.create(Object.create(null)));
// -> TypeError: proto.isPrototypeOf is not a function
```

Case 1 is the one that bites in practice: a `{}` built in a `node:vm` context, a worker, or an iframe does not share this realm's `Object.prototype`, so a value that is plain by every reasonable definition cannot be stored. Case 3 is a crash with a `TypeError` that does not mention unstorage at all.

## Fix

Check the prototype chain directly, the same shape as [`is-plain-obj`](https://github.com/sindresorhus/is-plain-obj):

```js
return proto === null || proto === Object.prototype || Object.getPrototypeOf(proto) === null;
```

`proto === Object.prototype` keeps the fast path for same-realm objects, and `Object.getPrototypeOf(proto) === null` accepts an `Object.prototype` from any realm (a plain object's prototype is always the last link in its chain). `Object.create(Function.prototype)` and `Object.create({})` now fall through to the `toJSON` branch and, absent one, raise the intended `[unstorage] Cannot stringify value!` instead of being silently accepted.

No behaviour changes for the values users actually store: object literals, `Object.create(null)` records, arrays, primitives, class instances and `toJSON` implementors all take the same path as before.

## Validation

Three regression tests added to `test/storage.test.ts` (the realm case, the non-plain rejection, and the null-prototyped-prototype case). All three fail on `main` and pass with the fix.

- `vitest run test/storage.test.ts test/server.test.ts test/tracing.test.ts test/drivers/{memory,fs,fs-lite,lru-cache,overlay}.test.ts` → 208 passed, no type errors
- `oxlint` and `oxfmt --check` clean on both changed files

Remaining `tsc --noEmit` errors (`cloudflare-r2-binding.ts`, `drivers/overlay.ts`, `drivers/utils/index.ts`) are pre-existing on `main` and untouched here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of plain objects created in other JavaScript realms.
  * Corrected support for objects with a null prototype.
  * Continued rejecting non-plain objects that cannot be safely serialized.
  * Added coverage to prevent related serialization errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->