### PR TITLE
feat(github): support writing files

### DIFF
--- a/docs/2.drivers/github.md
+++ b/docs/2.drivers/github.md
@@ -4,13 +4,13 @@ icon: mdi:github
 
 # GitHub
 
-> Read files from a remote GitHub repository.
+> Read and write files in a remote GitHub repository.
 
 ## Usage
 
 **Driver name:** `github`
 
-This read-only driver fetches the repository file list and caches it for 10 minutes by default. Providing a token is strongly recommended to avoid GitHub API rate limits. File contents are fetched separately from the raw content URL, using the same token.
+This driver fetches the repository file list and caches it for 10 minutes by default. Providing a token is strongly recommended to avoid GitHub API rate limits. File contents are fetched separately from the raw content URL, using the same token.
 
 ```js
 import { createStorage } from "unstorage";
@@ -62,3 +62,16 @@ const storage = createStorage({
 ::note
 GitHub Apps are not supported — use a personal access token.
 ::
+
+## Writing files
+
+To create, update, or delete files, provide a `token` with **Contents: read and write** access to the configured repository. Writes use the existing `branch` and `dir` options.
+
+With a driver configured for a repository and branch you can write to:
+
+```js
+await storage.setItem("comments/first.json", { message: "Hello!" });
+await storage.removeItem("comments/first.json");
+```
+
+Each successful file mutation creates a commit. Operations from one driver instance are serialized; batch writes and `clear()` are not atomic multi-file commits. GitHub API errors, including conflicts with other writers, are propagated.

--- a/src/drivers/github.ts
+++ b/src/drivers/github.ts
@@ -1,5 +1,5 @@
 import { createError, createRequiredError, type DriverFactory } from "./utils/index.ts";
-import { fetchRequest } from "./utils/fetch.ts";
+import { FetchError, fetchRequest } from "./utils/fetch.ts";
 import { withTrailingSlash, joinURL } from "./utils/path.ts";
 
 export interface GithubOptions {
@@ -9,7 +9,7 @@ export interface GithubOptions {
    */
   repo: string;
   /**
-   * The branch to fetch. (e.g. `dev`)
+   * The target branch. (e.g. `dev`)
    * @default "main"
    */
   branch?: string;
@@ -22,7 +22,7 @@ export interface GithubOptions {
    */
   ttl?: number;
   /**
-   * Github API token (recommended)
+   * Github API token (required for writes)
    */
   token?: string;
   /**
@@ -39,7 +39,7 @@ interface GithubFile {
   body?: string;
   meta: {
     sha: string;
-    mode: string;
+    mode?: string;
     size: number;
   };
 }
@@ -61,25 +61,100 @@ const driver: DriverFactory<GithubOptions> = (_opts) => {
 
   let files: Record<string, GithubFile> = {};
   let lastCheck = 0;
-  let syncPromise: undefined | Promise<any>;
+  let pendingOperation = Promise.resolve();
 
-  const syncFiles = async () => {
-    if (!opts.repo) {
-      throw createRequiredError(DRIVER_NAME, "repo");
-    }
-
-    if (lastCheck + opts.ttl! * 1000 > Date.now()) {
-      return;
-    }
-
-    if (!syncPromise) {
-      syncPromise = fetchFiles(opts);
-    }
-
-    files = await syncPromise;
-    lastCheck = Date.now();
-    syncPromise = undefined;
+  // Serialize mutations with tree refreshes so neither can overwrite the other's cache changes.
+  const enqueue = (operation: () => Promise<void>) => {
+    const result = pendingOperation.then(operation);
+    pendingOperation = result.catch(() => undefined);
+    return result;
   };
+
+  const syncFiles = () =>
+    enqueue(async () => {
+      if (!opts.repo) {
+        throw createRequiredError(DRIVER_NAME, "repo");
+      }
+
+      if (lastCheck + opts.ttl! * 1000 > Date.now()) {
+        return;
+      }
+
+      const updatedFiles = await fetchFiles(opts);
+      for (const [key, file] of Object.entries(updatedFiles)) {
+        if (file.meta.sha === files[key]?.meta.sha) {
+          file.body = files[key]?.body;
+        }
+      }
+      files = updatedFiles;
+      lastCheck = Date.now();
+    });
+
+  const writeFile = (key: string, value?: string) =>
+    enqueue(async () => {
+      if (!opts.repo || !opts.token) {
+        throw createRequiredError(DRIVER_NAME, !opts.repo ? "repo" : "token");
+      }
+
+      const path = withTrailingSlash(opts.dir).replace(/^\//, "") + key.replace(/:/g, "/");
+      const segments = path.split("/");
+      if (segments.some((segment) => segment === "." || segment === "..")) {
+        throw createError(DRIVER_NAME, "File paths must not contain dot segments");
+      }
+      const url = `/repos/${opts.repo}/contents/${segments.map(encodeURIComponent).join("/")}`;
+      const requestOptions = {
+        baseURL: opts.apiURL,
+        headers: {
+          "User-Agent": "unstorage",
+          Authorization: `token ${opts.token}`,
+          Accept: "application/vnd.github.object+json",
+        },
+      };
+      let sha: string | undefined;
+      try {
+        const res = await fetchRequest(url, {
+          ...requestOptions,
+          query: { ref: opts.branch },
+        });
+        sha = ((await res.json()) as { sha: string }).sha;
+      } catch (error) {
+        if (!(error instanceof FetchError) || error.status !== 404) {
+          throw error;
+        }
+      }
+
+      if (value === undefined && !sha) {
+        delete files[key];
+        lastCheck = -Infinity;
+        return;
+      }
+
+      const res = await fetchRequest(url, {
+        ...requestOptions,
+        method: value === undefined ? "DELETE" : "PUT",
+        body: {
+          branch: opts.branch,
+          sha,
+          message: `unstorage: ${value === undefined ? "remove" : "set"} ${path}`,
+          content:
+            value === undefined
+              ? undefined
+              : btoa(
+                  Array.from(new TextEncoder().encode(value), (byte) =>
+                    String.fromCodePoint(byte),
+                  ).join(""),
+                ),
+        },
+      });
+      if (value === undefined) {
+        delete files[key];
+      } else {
+        const { content } = (await res.json()) as { content: { sha: string; size: number } };
+        files[key] = { body: value, meta: { sha: content.sha, size: content.size } };
+      }
+      // The contents API omits mode; refresh the tree before exposing metadata.
+      lastCheck = -Infinity;
+    });
 
   return {
     name: DRIVER_NAME,
@@ -101,7 +176,7 @@ const driver: DriverFactory<GithubOptions> = (_opts) => {
         return null;
       }
 
-      if (!item.body) {
+      if (item.body === undefined) {
         try {
           const res = await fetchRequest(key.replace(/:/g, "/"), {
             baseURL: rawUrl,
@@ -117,6 +192,12 @@ const driver: DriverFactory<GithubOptions> = (_opts) => {
         }
       }
       return item.body;
+    },
+    setItem(key, value) {
+      return writeFile(key, value);
+    },
+    removeItem(key) {
+      return writeFile(key);
     },
     async getMeta(key) {
       await syncFiles();

--- a/src/drivers/github.ts
+++ b/src/drivers/github.ts
@@ -95,6 +95,9 @@ const driver: DriverFactory<GithubOptions> = (_opts) => {
       if (!opts.repo || !opts.token) {
         throw createRequiredError(DRIVER_NAME, !opts.repo ? "repo" : "token");
       }
+      if (new URL(opts.apiURL!).protocol !== "https:") {
+        throw createError(DRIVER_NAME, "apiURL must use HTTPS when writing with a token");
+      }
 
       const path = withTrailingSlash(opts.dir).replace(/^\//, "") + key.replace(/:/g, "/");
       const segments = path.split("/");
@@ -121,6 +124,9 @@ const driver: DriverFactory<GithubOptions> = (_opts) => {
         if (!(error instanceof FetchError) || error.status !== 404) {
           throw error;
         }
+        // A 404 can also mean that the repository or branch is inaccessible.
+        // Confirm that the target tree exists before treating the file as missing.
+        await fetchFiles(opts);
       }
 
       if (value === undefined && !sha) {

--- a/test/drivers/github-write.test.ts
+++ b/test/drivers/github-write.test.ts
@@ -1,0 +1,165 @@
+import { Buffer } from "node:buffer";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import driver, { type GithubOptions } from "../../src/drivers/github.ts";
+import { createStorage } from "../../src/index.ts";
+
+describe("drivers: github writes", () => {
+  const fetchMock = vi.fn<typeof fetch>();
+  const apiURL = "https://api.example.test";
+  const contentsURL = `${apiURL}/repos/owner/repo/contents/content`;
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    fetchMock.mockRejectedValue(new Error("Unexpected fetch"));
+    vi.stubGlobal("fetch", fetchMock);
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  const storageFor = (options: Partial<GithubOptions> = {}) =>
+    createStorage({
+      driver: driver({
+        repo: "owner/repo",
+        branch: "drafts",
+        dir: "/content",
+        token: "test-token",
+        apiURL,
+        ...options,
+      }),
+    });
+  const reply = (data: unknown, status = 200) =>
+    fetchMock.mockResolvedValueOnce(Response.json(data, { status }));
+  const blob = (path: string, sha: string, size = 0, mode = "100644") => ({
+    type: "blob",
+    path: `content/${path}`,
+    sha,
+    size,
+    mode,
+  });
+  const body = (index: number) => JSON.parse(fetchMock.mock.calls[index]![1]!.body as string);
+
+  it("creates UTF-8 content under the configured branch and directory", async () => {
+    const storage = storageFor();
+    const value = "é🌍".repeat(30_000);
+    const size = Buffer.byteLength(value);
+    reply({}, 404);
+    reply({ content: { sha: "created", size } }, 201);
+    reply({ tree: [blob("dir/a#b.txt", "created", size)] });
+
+    await storage.setItem("dir/a#b.txt", value);
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      `${contentsURL}/dir/a%23b.txt?ref=drafts`,
+      expect.objectContaining({
+        headers: {
+          authorization: "token test-token",
+          "user-agent": "unstorage",
+          accept: "application/vnd.github.object+json",
+        },
+      }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      `${contentsURL}/dir/a%23b.txt`,
+      expect.objectContaining({ method: "PUT" }),
+    );
+    expect(body(1)).toEqual({
+      branch: "drafts",
+      message: "unstorage: set content/dir/a#b.txt",
+      content: Buffer.from(value).toString("base64"),
+    });
+    expect(await storage.getItem("dir/a#b.txt")).toBe(value);
+    expect(await storage.hasItem("dir/a#b.txt")).toBe(true);
+    expect(await storage.getKeys()).toEqual(["dir:a#b.txt"]);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("updates with a fresh SHA and retains empty content across tree refreshes", async () => {
+    const storage = storageFor({ ttl: 0 });
+    reply({ tree: [blob("config.txt", "cached", 3, "100755")] });
+    fetchMock.mockResolvedValueOnce(new Response("old"));
+    expect(await storage.getItem("config.txt")).toBe("old");
+    reply({ sha: "external-update" });
+    reply({ content: { sha: "empty", size: 0 } });
+    for (let i = 0; i < 3; i++) {
+      reply({ tree: [blob("config.txt", "empty", 0, "100755")] });
+    }
+
+    await storage.setItem("config.txt", "");
+
+    expect(body(3)).toMatchObject({ sha: "external-update", content: "" });
+    expect(await storage.getItem("config.txt")).toBe("");
+    expect(await storage.getItem("config.txt")).toBe("");
+    expect(await storage.getMeta("config.txt", { nativeOnly: true })).toEqual({
+      sha: "empty",
+      size: 0,
+      mode: "100755",
+    });
+    reply({ tree: [blob("config.txt", "changed-again", 5, "100755")] });
+    fetchMock.mockResolvedValueOnce(new Response("other"));
+    expect(await storage.getItem("config.txt")).toBe("other");
+    expect(fetchMock).toHaveBeenCalledTimes(9);
+  });
+
+  it("deletes using the current SHA and ignores an already missing file", async () => {
+    const storage = storageFor();
+    reply({ tree: [blob("a", "cached"), blob("b", "kept")] });
+    await storage.getKeys();
+    reply({ sha: "current" });
+    reply({});
+    reply({ tree: [blob("b", "kept")] });
+    reply({}, 404);
+
+    await storage.removeItem("a");
+
+    expect(body(2)).toEqual({
+      branch: "drafts",
+      sha: "current",
+      message: "unstorage: remove content/a",
+    });
+    expect(await storage.hasItem("a")).toBe(false);
+    expect(await storage.getItem("a")).toBeNull();
+    expect(await storage.getKeys()).toEqual(["b"]);
+    await storage.removeItem("a");
+    expect(fetchMock.mock.calls.map(([, init]) => init?.method || "GET").join(" ")).toBe(
+      "GET GET DELETE GET GET",
+    );
+  });
+
+  it.each([403, 409])(
+    "propagates %s without changing cached data or poisoning later writes",
+    async (status) => {
+      const storage = storageFor();
+      reply({ tree: [blob("a", "old", 3)] });
+      fetchMock.mockResolvedValueOnce(new Response("old"));
+      expect(await storage.getItem("a")).toBe("old");
+      if (status === 409) {
+        reply({ sha: "old" });
+      }
+      reply({ message: "Request rejected" }, status);
+
+      await expect(storage.setItem("a", "rejected")).rejects.toMatchObject({ status });
+      expect(await storage.getItem("a")).toBe("old");
+
+      reply({ sha: "old" });
+      reply({ content: { sha: "new", size: 3 } });
+      reply({ tree: [blob("a", "new", 3)] });
+      await storage.setItem("a", "new");
+      expect(await storage.getItem("a")).toBe("new");
+    },
+  );
+
+  it.each(["repo", "token"] as const)("requires %s before writing", async (option) => {
+    const storage = storageFor({ [option]: "" });
+    await expect(storage.setItem("a", "value")).rejects.toThrow(
+      `Missing required option \`${option}\``,
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects dot segments instead of escaping the configured directory", async () => {
+    const storage = storageFor();
+    await expect(storage.setItem("../outside.txt", "value")).rejects.toThrow("dot segments");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/test/drivers/github-write.test.ts
+++ b/test/drivers/github-write.test.ts
@@ -42,6 +42,7 @@ describe("drivers: github writes", () => {
     const value = "é🌍".repeat(30_000);
     const size = Buffer.byteLength(value);
     reply({}, 404);
+    reply({ tree: [] });
     reply({ content: { sha: "created", size } }, 201);
     reply({ tree: [blob("dir/a#b.txt", "created", size)] });
 
@@ -60,10 +61,15 @@ describe("drivers: github writes", () => {
     );
     expect(fetchMock).toHaveBeenNthCalledWith(
       2,
+      `${apiURL}/repos/owner/repo/git/trees/drafts?recursive=1`,
+      expect.anything(),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      3,
       `${contentsURL}/dir/a%23b.txt`,
       expect.objectContaining({ method: "PUT" }),
     );
-    expect(body(1)).toEqual({
+    expect(body(2)).toEqual({
       branch: "drafts",
       message: "unstorage: set content/dir/a#b.txt",
       content: Buffer.from(value).toString("base64"),
@@ -71,7 +77,7 @@ describe("drivers: github writes", () => {
     expect(await storage.getItem("dir/a#b.txt")).toBe(value);
     expect(await storage.hasItem("dir/a#b.txt")).toBe(true);
     expect(await storage.getKeys()).toEqual(["dir:a#b.txt"]);
-    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(fetchMock).toHaveBeenCalledTimes(4);
   });
 
   it("updates with a fresh SHA and retains empty content across tree refreshes", async () => {
@@ -109,6 +115,7 @@ describe("drivers: github writes", () => {
     reply({});
     reply({ tree: [blob("b", "kept")] });
     reply({}, 404);
+    reply({ tree: [blob("b", "kept")] });
 
     await storage.removeItem("a");
 
@@ -122,8 +129,17 @@ describe("drivers: github writes", () => {
     expect(await storage.getKeys()).toEqual(["b"]);
     await storage.removeItem("a");
     expect(fetchMock.mock.calls.map(([, init]) => init?.method || "GET").join(" ")).toBe(
-      "GET GET DELETE GET GET",
+      "GET GET DELETE GET GET GET",
     );
+  });
+
+  it("propagates a 404 when the repository or branch is inaccessible", async () => {
+    const storage = storageFor();
+    reply({}, 404);
+    reply({}, 404);
+
+    await expect(storage.setItem("a", "value")).rejects.toThrow("Failed to fetch git tree");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
   it.each([403, 409])(
@@ -160,6 +176,12 @@ describe("drivers: github writes", () => {
   it("rejects dot segments instead of escaping the configured directory", async () => {
     const storage = storageFor();
     await expect(storage.setItem("../outside.txt", "value")).rejects.toThrow("dot segments");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects an insecure API URL before sending the token", async () => {
+    const storage = storageFor({ apiURL: "http://api.example.test" });
+    await expect(storage.setItem("a", "value")).rejects.toThrow("apiURL must use HTTPS");
     expect(fetchMock).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- add setItem and removeItem support to the GitHub driver through the Contents API
- create and update UTF-8 files on the configured branch and directory
- serialize mutations, refresh cached tree metadata, and propagate API conflicts

Closes #679

## Tests
- GitHub write tests (8 passed with type checking)
- pnpm test (573 passed, 208 skipped)
- pnpm build and pnpm test:types

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GitHub-backed storage supports creating, updating, and deleting files.
  * Changes are committed to the configured branch, with cached content and metadata refreshed afterward.
  * File operations are serialized per driver instance for safer concurrent use.

* **Bug Fixes**
  * Empty files remain correctly cached.
  * Missing files and write conflicts are handled without corrupting subsequent operations.
  * Invalid paths and insecure API URLs are rejected.

* **Documentation**
  * Added guidance for write permissions, branch targeting, mutations, and error behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->